### PR TITLE
docs: fix documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,6 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) fo
 
 ## [Unreleased]
 
-## [0.1.0] - 2021-11-15
+## [0.0.1-preview.1] - 2022-08-01
 ### Added
-- Public beta release
+- Public preview release

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 AWS Lambda Powertools for .NET (C#) is suite of utilities for AWS Lambda functions to simplify implementation of serverless observability best practices such as tracing, structured logging, custom metrics.
 
-**[📜 Documentation](https://awslabs.github.io/aws-lambda-powertools-dotnet/)** | **[NuGet](https://www.nuget.org/)** | **[Roadmap](https://github.com/awslabs/aws-lambda-powertools-roadmap/projects/1)** | **[Examples](#examples)** | **[Blog post](https://aws.amazon.com/blogs/opensource/simplifying-serverless-best-practices-with-lambda-powertools/)**
+**[📜 Documentation](https://awslabs.github.io/aws-lambda-powertools-dotnet/)** | **[NuGet](https://www.nuget.org/)** | **[Roadmap](https://github.com/awslabs/aws-lambda-powertools-roadmap/projects/1)** | **[Examples](#examples)**
 
 > **Join us on the AWS Developers Slack at `#lambda-powertools`** - **[Invite, if you don't have an account](https://join.slack.com/t/awsdevelopers/shared_invite/zt-gu30gquv-EhwIYq3kHhhysaZ2aIX7ew)**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ The GitHub repository for this project can be found [here](https://github.com/aw
 
 !!! warning  "Do not use this library in production"
 
-    **AWS Lambda Powertools for .NET is currently released as a alpha developer preview** and is intended strictly for feedback purposes only. This version is not stable, and significant breaking changes might incur as part of the upcoming production-ready release.
+    **AWS Lambda Powertools for .NET is currently released in preview** and is intended strictly for feedback purposes only. This version is not stable, and significant breaking changes might incur as part of the upcoming production-ready release.
 
     Your support is much appreciated. If you encounter any problems, [please raise an issue](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/new/choose).
 
@@ -24,9 +24,6 @@ The GitHub repository for this project can be found [here](https://github.com/aw
 [Tracing](./core/tracing.md) | Decorators and utilities to trace Lambda function handlers, and both synchronous and asynchronous functions
 [Logger](./core/logging.md) | Structured logging made easier, and decorator to enrich structured logging with key Lambda context details
 [Metrics](./core/metrics.md) | Custom AWS metrics created asynchronously via CloudWatch Embedded Metric Format (EMF)
-
-!!! info "Looking for a quick read through how the core features are used?"
-   Check out the [Simplifying serverless best practices with Lambda Powertools](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-powertools-for-net) blog post with a practical example.
 
 ## Install
 
@@ -62,9 +59,9 @@ To use the SAM CLI, you need the following tools.
 
 We have provided a few examples that should you how to use the each of the core Powertools features.
 
-* [Tracer](https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/main/examples/tracer){target="_blank"} example
-* [Logger](https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/main/examples/logger/){target="_blank"} example
-* [Metrics](https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/main/examples/metrics/){target="_blank"} example
+* [Tracing](https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/main/examples/Tracing){target="_blank"} example
+* [Logging](https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/main/examples/Logging/){target="_blank"} example
+* [Metrics](https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/main/examples/Metrics/){target="_blank"} example
 
 ## Other members of the AWS Lambda Powertools family
 


### PR DESCRIPTION
**Issue number:** #146

## Summary

This PR fixes the broken links in the documentation

### Changes

- Link updates

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

-----
[View rendered CHANGELOG.md](https://github.com/amirkaws/aws-lambda-powertools-dotnet/blob/amirkaws-fix-doc-links/CHANGELOG.md)
[View rendered README.md](https://github.com/amirkaws/aws-lambda-powertools-dotnet/blob/amirkaws-fix-doc-links/README.md)
[View rendered docs/index.md](https://github.com/amirkaws/aws-lambda-powertools-dotnet/blob/amirkaws-fix-doc-links/docs/index.md)