### PR TITLE
docs: typo in metrics README

### DIFF
--- a/examples/Metrics/README.md
+++ b/examples/Metrics/README.md
@@ -1,4 +1,4 @@
-# AWS Lambda Powertools for .NET - Logging Example
+# AWS Lambda Powertools for .NET - Metrics Example
 
 This project contains source code and supporting files for a serverless application that you can deploy with the AWS Serverless Application Model Command Line Interface (AWS SAM CLI). It includes the following files and folders.
 


### PR DESCRIPTION
## Summary

Related issue: https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/162

### Changes

> Please provide a summary of what's being changed

Fixed a small typo in the Metrics example title for future readers.

### User experience

> Please share what the user experience looks like before and after this change

Only docs change.

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

No.

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

-----
[View rendered examples/Metrics/README.md](https://github.com/kenfdev/aws-lambda-powertools-dotnet/blob/fix-readme-title-typo/examples/Metrics/README.md)