### PR TITLE
fix: updated logger casing env vars in samples

### DIFF
--- a/examples/Logging/template-docker.yaml
+++ b/examples/Logging/template-docker.yaml
@@ -13,7 +13,7 @@ Globals:
       Variables:
         POWERTOOLS_SERVICE_NAME: powertools-dotnet-logging-sample
         POWERTOOLS_LOG_LEVEL: Debug
-        POWERTOOLS_LOGGER_CASE: SnakeCase # Allowed values are: CamelCase, PascalCase and SnakeCase
+        POWERTOOLS_LOGGER_CASE: PascalCase # Allowed values are: CamelCase, PascalCase and SnakeCase
 
 Resources:
   HelloWorldFunction:

--- a/examples/Logging/template.yaml
+++ b/examples/Logging/template.yaml
@@ -13,7 +13,7 @@ Globals:
       Variables:
         POWERTOOLS_SERVICE_NAME: powertools-dotnet-logging-sample
         POWERTOOLS_LOG_LEVEL: Debug
-        POWERTOOLS_LOGGER_CASE: SnakeCase # Allowed values are: CamelCase, PascalCase and SnakeCase
+        POWERTOOLS_LOGGER_CASE: PascalCase # Allowed values are: CamelCase, PascalCase and SnakeCase
 
 Resources:
   HelloWorldFunction:

--- a/examples/Metrics/template-docker.yaml
+++ b/examples/Metrics/template-docker.yaml
@@ -13,7 +13,7 @@ Globals:
       Variables:
         POWERTOOLS_SERVICE_NAME: powertools-dotnet-metrics-sample # This can also be set using the Metrics decorator on your handler [Metrics(Namespace = "aws-lambda-powertools"]
         POWERTOOLS_LOG_LEVEL: Debug
-        POWERTOOLS_LOGGER_CASE: SnakeCase # Allowed values are: CamelCase, PascalCase and SnakeCase (default)
+        POWERTOOLS_LOGGER_CASE: PascalCase # Allowed values are: CamelCase, PascalCase and SnakeCase (default)
         POWERTOOLS_METRICS_NAMESPACE: AWSLambdaPowertools # This can also be set using the Metrics decorator on your handler [Metrics(Namespace = "aws-lambda-powertools"]
 
 Resources:

--- a/examples/Metrics/template.yaml
+++ b/examples/Metrics/template.yaml
@@ -13,7 +13,7 @@ Globals:
       Variables:
         POWERTOOLS_SERVICE_NAME: powertools-dotnet-metrics-sample # This can also be set using the Metrics decorator on your handler [Metrics(Namespace = "aws-lambda-powertools"]
         POWERTOOLS_LOG_LEVEL: Debug
-        POWERTOOLS_LOGGER_CASE: SnakeCase # Allowed values are: CamelCase, PascalCase and SnakeCase (default)
+        POWERTOOLS_LOGGER_CASE: PascalCase # Allowed values are: CamelCase, PascalCase and SnakeCase (default)
         POWERTOOLS_METRICS_NAMESPACE: AWSLambdaPowertools # This can also be set using the Metrics decorator on your handler [Metrics(Namespace = "aws-lambda-powertools"]
 
 Resources:

--- a/examples/Tracing/template-docker.yaml
+++ b/examples/Tracing/template-docker.yaml
@@ -13,7 +13,7 @@ Globals:
       Variables:
         POWERTOOLS_SERVICE_NAME: powertools-dotnet-tracing-sample
         POWERTOOLS_LOG_LEVEL: Debug
-        POWERTOOLS_LOGGER_CASE: SnakeCase # Allowed values are: CamelCase, PascalCase and SnakeCase
+        POWERTOOLS_LOGGER_CASE: PascalCase # Allowed values are: CamelCase, PascalCase and SnakeCase
 
 Resources:
   HelloWorldFunction:

--- a/examples/Tracing/template.yaml
+++ b/examples/Tracing/template.yaml
@@ -14,7 +14,7 @@ Globals:
       Variables:
         POWERTOOLS_SERVICE_NAME: powertools-dotnet-tracing-sample
         POWERTOOLS_LOG_LEVEL: Debug
-        POWERTOOLS_LOGGER_CASE: SnakeCase # Allowed values are: CamelCase, PascalCase and SnakeCase (Default)
+        POWERTOOLS_LOGGER_CASE: PascalCase # Allowed values are: CamelCase, PascalCase and SnakeCase (Default)
         POWERTOOLS_TRACER_CAPTURE_RESPONSE: true
         POWERTOOLS_TRACER_CAPTURE_ERROR: true     # To disable tracing (CaptureMode = TracingCaptureMode.Disabled)
 


### PR DESCRIPTION
**Issue number:** #176 

## Summary
Pascal casing used by default in example projects

### Changes

> Please provide a summary of what's being changed
Changed `POWERTOOLS_LOGGER_CASE` environment variable from `SnakeCase` to `PascalCase` in sample projects.

### User experience

> Please share what the user experience looks like before and after this change
Casing will be Pascal case by default for log entries.

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.