### PR TITLE
fix: update NuGet references for examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) fo
 
 ## [Unreleased]
 
+## [0.0.2-preview] - 2023-01-18
 ## [0.0.1-preview.1] - 2022-08-01
 ### Added
 - Public preview release

--- a/examples/Logging/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Logging/src/HelloWorld/HelloWorld.csproj
@@ -8,7 +8,7 @@
         <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
         <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="0.0.1-preview.1" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="0.0.2-preview" />
         <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.14" />
     </ItemGroup>
 </Project>

--- a/examples/Metrics/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Metrics/src/HelloWorld/HelloWorld.csproj
@@ -8,8 +8,8 @@
         <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
         <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="0.0.1-preview.1" />
-        <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="0.0.1-preview.1" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="0.0.2-preview" />
+        <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="0.0.2-preview" />
         <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.14" />
     </ItemGroup>
 </Project>

--- a/examples/Tracing/src/HelloWorld/HelloWorld.csproj
+++ b/examples/Tracing/src/HelloWorld/HelloWorld.csproj
@@ -8,8 +8,8 @@
         <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
         <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="0.0.1-preview.1" />
-        <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="0.0.1-preview.1" />
+        <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="0.0.2-preview" />
+        <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="0.0.2-preview" />
         <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.14" />
         <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.11.0" />
     </ItemGroup>


### PR DESCRIPTION
**Issue number:** 184

## Summary

Update NuGet references for examples projects

### Changes

Update to version 0.0.2-preview

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.