### PR TITLE
chore(docs): fix incorrect crefs

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggerProvider.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggerProvider.cs
@@ -22,9 +22,9 @@ namespace AWS.Lambda.Powertools.Logging.Internal;
 
 /// <summary>
 ///     Class LoggerProvider. This class cannot be inherited.
-///     Implements the <see cref="Microsoft.Extensions.Logging.ILoggerProvider" />
+///     Implements the <see cref="T:Microsoft.Extensions.Logging.ILoggerProvider" />
 /// </summary>
-/// <seealso cref="Microsoft.Extensions.Logging.ILoggerProvider" />
+/// <seealso cref="T:Microsoft.Extensions.Logging.ILoggerProvider" />
 public sealed class LoggerProvider : ILoggerProvider
 {
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Logging/LoggerConfiguration.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/LoggerConfiguration.cs
@@ -21,9 +21,9 @@ namespace AWS.Lambda.Powertools.Logging;
 /// <summary>
 ///     Class LoggerConfiguration.
 ///     Implements the
-///     <see cref="Microsoft.Extensions.Options.IOptions{LoggerConfiguration}" />
+///     <see cref="T:Microsoft.Extensions.Options.IOptions{LoggerConfiguration}" />
 /// </summary>
-/// <seealso cref="Microsoft.Extensions.Options.IOptions{LoggerConfiguration}" />
+/// <seealso cref="T:Microsoft.Extensions.Options.IOptions{LoggerConfiguration}" />
 public class LoggerConfiguration : IOptions<LoggerConfiguration>
 {
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Logging/LoggerExtensions.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/LoggerExtensions.cs
@@ -29,7 +29,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes a trace log message as JSON.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="message">The object to be serialized as JSON.</param>
     /// <example>logger.LogTrace(new {User = user, Address = address})</example>
     public static void LogTrace(this ILogger logger, object message)
@@ -40,7 +40,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes an trace log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="exception">The exception to log.</param>
     /// <example>logger.LogTrace(exception)</example>
     public static void LogTrace(this ILogger logger, Exception exception)
@@ -51,7 +51,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes a debug log message as JSON.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="message">The object to be serialized as JSON.</param>
     /// <example>logger.LogDebug(new {User = user, Address = address})</example>
     public static void LogDebug(this ILogger logger, object message)
@@ -62,7 +62,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes an debug log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="exception">The exception to log.</param>
     /// <example>logger.LogDebug(exception)</example>
     public static void LogDebug(this ILogger logger, Exception exception)
@@ -73,7 +73,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes an information log message as JSON.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="message">The object to be serialized as JSON.</param>
     /// <example>logger.LogInformation(new {User = user, Address = address})</example>
     public static void LogInformation(this ILogger logger, object message)
@@ -84,7 +84,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes an information log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="exception">The exception to log.</param>
     /// <example>logger.LogInformation(exception)</example>
     public static void LogInformation(this ILogger logger, Exception exception)
@@ -95,7 +95,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes a warning log message as JSON.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="message">The object to be serialized as JSON.</param>
     /// <example>logger.LogWarning(new {User = user, Address = address})</example>
     public static void LogWarning(this ILogger logger, object message)
@@ -106,7 +106,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes an warning log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="exception">The exception to log.</param>
     /// <example>logger.LogWarning(exception)</example>
     public static void LogWarning(this ILogger logger, Exception exception)
@@ -117,7 +117,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes a error log message as JSON.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="message">The object to be serialized as JSON.</param>
     /// <example>logger.LogCritical(new {User = user, Address = address})</example>
     public static void LogError(this ILogger logger, object message)
@@ -128,7 +128,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes an error log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="exception">The exception to log.</param>
     /// <example>logger.LogError(exception)</example>
     public static void LogError(this ILogger logger, Exception exception)
@@ -139,7 +139,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes a critical log message as JSON.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="message">The object to be serialized as JSON.</param>
     /// <example>logger.LogCritical(new {User = user, Address = address})</example>
     public static void LogCritical(this ILogger logger, object message)
@@ -150,7 +150,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes an critical log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="exception">The exception to log.</param>
     /// <example>logger.LogCritical(exception)</example>
     public static void LogCritical(this ILogger logger, Exception exception)
@@ -161,7 +161,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes a log message as JSON at the specified log level.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="logLevel">Entry will be written on this level.</param>
     /// <param name="message">The object to be serialized as JSON.</param>
     /// <example>logger.Log(LogLevel.Information, new {User = user, Address = address})</example>
@@ -173,7 +173,7 @@ public static class LoggerExtensions
     /// <summary>
     ///     Formats and writes a log message at the specified log level.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger" /> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger" /> to write to.</param>
     /// <param name="logLevel">Entry will be written on this level.</param>
     /// <param name="exception">The exception to log.</param>
     /// <example>logger.Log(LogLevel.Information, exception)</example>
@@ -191,7 +191,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a debug log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
     /// <param name="exception">The exception to log.</param>
@@ -207,7 +207,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a debug log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
@@ -222,7 +222,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a debug log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="exception">The exception to log.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
@@ -237,7 +237,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a debug log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
@@ -254,7 +254,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a trace log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
     /// <param name="exception">The exception to log.</param>
@@ -270,7 +270,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a trace log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
@@ -285,7 +285,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a trace log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="exception">The exception to log.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
@@ -300,7 +300,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a trace log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
@@ -317,7 +317,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes an informational log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
     /// <param name="exception">The exception to log.</param>
@@ -333,7 +333,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes an informational log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
@@ -348,7 +348,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes an informational log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="exception">The exception to log.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
@@ -363,7 +363,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes an informational log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
@@ -380,7 +380,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a warning log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
     /// <param name="exception">The exception to log.</param>
@@ -396,7 +396,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a warning log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
@@ -411,7 +411,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a warning log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="exception">The exception to log.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
@@ -426,7 +426,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a warning log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
@@ -443,7 +443,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes an error log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
     /// <param name="exception">The exception to log.</param>
@@ -459,7 +459,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes an error log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
@@ -474,7 +474,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes an error log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="exception">The exception to log.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
@@ -489,7 +489,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes an error log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
@@ -506,7 +506,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a critical log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
     /// <param name="exception">The exception to log.</param>
@@ -522,7 +522,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a critical log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
@@ -537,7 +537,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a critical log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="exception">The exception to log.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
@@ -552,7 +552,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a critical log message.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>
     /// <param name="args">An object array that contains zero or more objects to format.</param>
@@ -569,7 +569,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a log message at the specified log level.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="logLevel">Entry will be written on this level.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
@@ -592,7 +592,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a log message at the specified log level.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="logLevel">Entry will be written on this level.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="eventId">The event id associated with the log.</param>
@@ -608,7 +608,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a log message at the specified log level.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="logLevel">Entry will be written on this level.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="exception">The exception to log.</param>
@@ -624,7 +624,7 @@ public static class LoggerExtensions
     /// <summary>
     /// Formats and writes a log message at the specified log level.
     /// </summary>
-    /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+    /// <param name="logger">The <see cref="T:Microsoft.Extensions.Logging.ILogger"/> to write to.</param>
     /// <param name="logLevel">Entry will be written on this level.</param>
     /// <param name="extraKeys">Additional keys will be appended to the log entry.</param>
     /// <param name="message">Format string of the log message in message template format. Example: <c>"User {User} logged in from {Address}"</c></param>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Serializer/JsonNamingPolicyDecorator.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Serializer/JsonNamingPolicyDecorator.cs
@@ -19,7 +19,11 @@ public class JsonNamingPolicyDecorator : JsonNamingPolicy
         _underlyingNamingPolicy = underlyingNamingPolicy;
     }
     
-    /// <inheritdoc />
+    /// <summary>
+    /// When overridden in a derived class, converts the specified name according to the policy.
+    /// </summary>
+    /// <param name="name">The name to convert.</param>
+    /// <returns>The converted name.</returns>
     public override string ConvertName(string name)
     {
         return _underlyingNamingPolicy == null ? name : _underlyingNamingPolicy.ConvertName(name);


### PR DESCRIPTION
**Issue number**: #191

## Summary

### Changes

* Updated crefs to have the fully qualified name of the type

### User experience


## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**: #191 

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.