### PR TITLE
bug: fix flaky test, add relaxed json escaping

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using AWS.Lambda.Powertools.Common;
 using AWS.Lambda.Powertools.Logging.Internal.Converters;
@@ -355,6 +356,9 @@ internal sealed class PowertoolsLogger : ILogger
         jsonOptions.Converters.Add(new ExceptionConverter());
         jsonOptions.Converters.Add(new MemoryStreamConverter());
         jsonOptions.Converters.Add(new ConstantClassConverter());
+        
+        jsonOptions.Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping;
+        
         return jsonOptions;
     }
 }


### PR DESCRIPTION
> Please provide the issue number

Issue number: #201

## Summary
Currently the plus sign is escaped and transformed into "\u002B". This is not the expected behaviour because it will break bas64 encoding/decoding.

Added new test that tests a static string that contains + sign when encoded. 

### Changes

```jsonOptions.Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping;```

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
