### PR TITLE
fix: ColdStart capture warning

### DIFF
--- a/examples/Metrics/src/HelloWorld/Function.cs
+++ b/examples/Metrics/src/HelloWorld/Function.cs
@@ -74,8 +74,7 @@ public class Function
     /// <returns>API Gateway Proxy response</returns>
     [Logging(LogEvent = true)]
     [Metrics(CaptureColdStart = true)]
-    public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigwProxyEvent,
-        ILambdaContext context)
+    public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigwProxyEvent, ILambdaContext context)
     {
         var requestContextRequestId = apigwProxyEvent.RequestContext.RequestId;
 

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Internal/MetricsAspectHandler.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Internal/MetricsAspectHandler.cs
@@ -78,8 +78,14 @@ internal class MetricsAspectHandler : IMethodAspectHandler
     /// <param name="eventArgs">Aspect Arguments</param>
     public void OnEntry(AspectEventArgs eventArgs)
     {
-        if (!_isColdStart || !_captureColdStartEnabled) return;
-
+        if (!_isColdStart)
+            return;
+        
+        _isColdStart = false;
+        
+        if (!_captureColdStartEnabled) 
+            return;
+        
         var nameSpace = _metrics.GetNamespace();
         var service = _metrics.GetService();
         Dictionary<string, string> dimensions = null;
@@ -102,8 +108,6 @@ internal class MetricsAspectHandler : IMethodAspectHandler
             service,
             dimensions
         );
-
-        _isColdStart = false;
     }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/MetricsAttribute.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/MetricsAttribute.cs
@@ -139,7 +139,8 @@ public class MetricsAttribute : MethodAspectAttribute
             PowertoolsConfigurations.Instance,
             Namespace,
             Service,
-            RaiseOnEmptyMetrics
+            RaiseOnEmptyMetrics,
+            CaptureColdStart
         );
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/Metadata.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/Metadata.cs
@@ -30,6 +30,7 @@ public class Metadata
     public Metadata()
     {
         CloudWatchMetrics = new List<MetricDirective> {new()};
+        Timestamp = DateTime.Now;
         CustomMetadata = new Dictionary<string, object>();
     }
 
@@ -38,7 +39,7 @@ public class Metadata
     /// </summary>
     /// <value>The timestamp.</value>
     [JsonConverter(typeof(UnixMillisecondDateTimeConverter))]
-    public DateTime Timestamp => DateTime.Now;
+    public DateTime Timestamp { get; }
 
     /// <summary>
     ///     Gets the cloud watch metrics.

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/Metadata.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/Metadata.cs
@@ -30,7 +30,6 @@ public class Metadata
     public Metadata()
     {
         CloudWatchMetrics = new List<MetricDirective> {new()};
-        Timestamp = DateTime.Now;
         CustomMetadata = new Dictionary<string, object>();
     }
 
@@ -39,7 +38,7 @@ public class Metadata
     /// </summary>
     /// <value>The timestamp.</value>
     [JsonConverter(typeof(UnixMillisecondDateTimeConverter))]
-    public DateTime Timestamp { get; }
+    public DateTime Timestamp => DateTime.Now;
 
     /// <summary>
     ///     Gets the cloud watch metrics.

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/EMFValidationTests.cs
@@ -34,6 +34,7 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             // Arrange
             var methodName = Guid.NewGuid().ToString();
             var consoleOut = new StringWriter();
+            const bool captureColdStartEnabled = true;
             Console.SetOut(consoleOut);
 
             var configurations = new Mock<IPowertoolsConfigurations>();
@@ -41,12 +42,13 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var logger = new Metrics(
                 configurations.Object,
                 nameSpace: "dotnet-powertools-test",
-                service: "testService"
+                service: "testService",
+                captureColdStartEnabled: captureColdStartEnabled
             );
 
             var handler = new MetricsAspectHandler(
                 logger,
-                true
+                captureColdStartEnabled
             );
 
             var eventArgs = new AspectEventArgs { Name = methodName };
@@ -74,6 +76,7 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             // Arrange
             var methodName = Guid.NewGuid().ToString();
             var consoleOut = new StringWriter();
+            const bool captureColdStartEnabled = true;
             Console.SetOut(consoleOut);
 
             var configurations = new Mock<IPowertoolsConfigurations>();
@@ -81,12 +84,13 @@ namespace AWS.Lambda.Powertools.Metrics.Tests
             var logger = new Metrics(
                 configurations.Object,
                 nameSpace: "dotnet-powertools-test",
-                service: "testService"
+                service: "testService",
+                captureColdStartEnabled: captureColdStartEnabled
             );
 
             var handler = new MetricsAspectHandler(
                 logger,
-                true
+                captureColdStartEnabled
             );
 
             var eventArgs = new AspectEventArgs { Name = methodName };


### PR DESCRIPTION
> Please provide the issue number

Issue number: 206

## Summary
This PR addresses warning messages raised when coldstart up metrics is being captured.

### Changes

> Please provide a summary of what's being changed

Logic for empty metrics is changed not to show warning when user capture ColdStart metric

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
