### PR TITLE
fix: Wrong metrics timestamp

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Model/Metadata.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Model/Metadata.cs
@@ -30,7 +30,6 @@ public class Metadata
     public Metadata()
     {
         CloudWatchMetrics = new List<MetricDirective> {new()};
-        Timestamp = DateTime.Now;
         CustomMetadata = new Dictionary<string, object>();
     }
 
@@ -39,7 +38,7 @@ public class Metadata
     /// </summary>
     /// <value>The timestamp.</value>
     [JsonConverter(typeof(UnixMillisecondDateTimeConverter))]
-    public DateTime Timestamp { get; }
+    public DateTime Timestamp => DateTime.Now;
 
     /// <summary>
     ///     Gets the cloud watch metrics.


### PR DESCRIPTION
> Please provide the issue number

Issue number: 207

## Summary

This PR addresses the incorrect metrics timestamp

### Changes

> Please provide a summary of what's being changed

Timestamp for the context has change to generate a new time every time context flushes and serialises EMF metrics to CloudWatch logs

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
