### PR TITLE
Fix Tracing when exception is thrown. Prevent Tracing from throwing InvalidOperationException

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingAspectHandler.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingAspectHandler.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using System.Text;
 using AWS.Lambda.Powertools.Common;
 
 namespace AWS.Lambda.Powertools.Tracing.Internal;
@@ -164,24 +165,25 @@ internal class TracingAspectHandler : IMethodAspectHandler
         {
             var nameSpace = GetNamespace();
             
-            var message =
-                "Exception type " + exception.GetType() + Environment.NewLine +
-                "Exception message: " + exception.Message + Environment.NewLine +
-                "Stack trace: " + exception.StackTrace + Environment.NewLine;
+            var sb = new StringBuilder();
+            sb.AppendLine($"Exception type: {exception.GetType()}");
+            sb.AppendLine($"Exception message: {exception.Message}");
+            sb.AppendLine($"Stack trace: {exception.StackTrace}");
+
             if (exception.InnerException != null)
             {
-                message += "---BEGIN InnerException--- " + Environment.NewLine +
-                           "Exception type " + exception.InnerException.GetType() + Environment.NewLine +
-                           "Exception message: " + exception.InnerException.Message + Environment.NewLine +
-                           "Stack trace: " + exception.InnerException.StackTrace + Environment.NewLine +
-                           "---END Inner Exception";
+                sb.AppendLine("---BEGIN InnerException--- ");
+                sb.AppendLine($"Exception type {exception.InnerException.GetType()}");
+                sb.AppendLine($"Exception message: {exception.InnerException.Message}");
+                sb.AppendLine($"Stack trace: {exception.InnerException.StackTrace}");
+                sb.AppendLine("---END Inner Exception");
             }
             
             _xRayRecorder.AddMetadata
             (
                 nameSpace,
                 $"{eventArgs.Name} error",
-                message
+                sb.ToString()
             );
         }
 

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingAspectHandler.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingAspectHandler.cs
@@ -163,12 +163,25 @@ internal class TracingAspectHandler : IMethodAspectHandler
         if (CaptureError())
         {
             var nameSpace = GetNamespace();
-
+            
+            var message =
+                "Exception type " + exception.GetType() + Environment.NewLine +
+                "Exception message: " + exception.Message + Environment.NewLine +
+                "Stack trace: " + exception.StackTrace + Environment.NewLine;
+            if (exception.InnerException != null)
+            {
+                message += "---BEGIN InnerException--- " + Environment.NewLine +
+                           "Exception type " + exception.InnerException.GetType() + Environment.NewLine +
+                           "Exception message: " + exception.InnerException.Message + Environment.NewLine +
+                           "Stack trace: " + exception.InnerException.StackTrace + Environment.NewLine +
+                           "---END Inner Exception";
+            }
+            
             _xRayRecorder.AddMetadata
             (
                 nameSpace,
                 $"{eventArgs.Name} error",
-                exception
+                message
             );
         }
 

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingAttributeTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingAttributeTest.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Linq;
+using System.Text;
 using AWS.Lambda.Powertools.Common;
 using AWS.Lambda.Powertools.Tracing.Internal;
 using Moq;
@@ -768,19 +769,20 @@ namespace AWS.Lambda.Powertools.Tracing.Tests
 
         static string GetException(Exception exception)
         {
-            var message =
-                "Exception type " + exception.GetType() + Environment.NewLine +
-                "Exception message: " + exception.Message + Environment.NewLine +
-                "Stack trace: " + exception.StackTrace + Environment.NewLine;
+            var sb = new StringBuilder();
+            sb.AppendLine($"Exception type: {exception.GetType()}");
+            sb.AppendLine($"Exception message: {exception.Message}");
+            sb.AppendLine($"Stack trace: {exception.StackTrace}");
+
             if (exception.InnerException != null)
             {
-                message += "---BEGIN InnerException--- " + Environment.NewLine +
-                           "Exception type " + exception.InnerException.GetType() + Environment.NewLine +
-                           "Exception message: " + exception.InnerException.Message + Environment.NewLine +
-                           "Stack trace: " + exception.InnerException.StackTrace + Environment.NewLine +
-                           "---END Inner Exception";
+                sb.AppendLine("---BEGIN InnerException--- ");
+                sb.AppendLine($"Exception type {exception.InnerException.GetType()}");
+                sb.AppendLine($"Exception message: {exception.InnerException.Message}");
+                sb.AppendLine($"Stack trace: {exception.InnerException.StackTrace}");
+                sb.AppendLine("---END Inner Exception");
             }
-            return message;
+            return sb.ToString();
         }
 
         #endregion

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingAttributeTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/TracingAttributeTest.cs
@@ -590,7 +590,8 @@ namespace AWS.Lambda.Powertools.Tracing.Tests
             configurations.Setup(c => c.TracerCaptureError).Returns(true);
             var recorder = new Mock<IXRayRecorder>();
             var exception = new Exception("Test Exception");
-
+            var message = GetException(exception);
+            
             var handler = new TracingAspectHandler(null, nameSpace, TracingCaptureMode.EnvironmentVariable,
                 configurations.Object, recorder.Object);
             var eventArgs = new AspectEventArgs {Name = methodName};
@@ -604,7 +605,7 @@ namespace AWS.Lambda.Powertools.Tracing.Tests
                 v.AddMetadata(
                     It.Is<string>(i => i == nameSpace),
                     It.Is<string>(i => i == $"{methodName} error"),
-                    It.Is<Exception>(i => i == exception
+                    It.Is<string>(i => i == message
                     )
                 ), Times.Once);
         }
@@ -650,7 +651,8 @@ namespace AWS.Lambda.Powertools.Tracing.Tests
             configurations.Setup(c => c.TracingDisabled).Returns(false);
             var recorder = new Mock<IXRayRecorder>();
             var exception = new Exception("Test Exception");
-
+            var message = GetException(exception);
+            
             var handler = new TracingAspectHandler(null, nameSpace, TracingCaptureMode.Error,
                 configurations.Object, recorder.Object);
             var eventArgs = new AspectEventArgs {Name = methodName};
@@ -664,7 +666,7 @@ namespace AWS.Lambda.Powertools.Tracing.Tests
                 v.AddMetadata(
                     It.Is<string>(i => i == nameSpace),
                     It.Is<string>(i => i == $"{methodName} error"),
-                    It.Is<Exception>(i => i == exception
+                    It.Is<string>(i => i == message
                     )
                 ), Times.Once);
         }
@@ -680,7 +682,8 @@ namespace AWS.Lambda.Powertools.Tracing.Tests
             configurations.Setup(c => c.TracingDisabled).Returns(false);
             var recorder = new Mock<IXRayRecorder>();
             var exception = new Exception("Test Exception");
-
+            var message = GetException(exception);
+            
             var handler = new TracingAspectHandler(null, nameSpace, TracingCaptureMode.ResponseAndError,
                 configurations.Object, recorder.Object);
             var eventArgs = new AspectEventArgs {Name = methodName};
@@ -694,7 +697,7 @@ namespace AWS.Lambda.Powertools.Tracing.Tests
                 v.AddMetadata(
                     It.Is<string>(i => i == nameSpace),
                     It.Is<string>(i => i == $"{methodName} error"),
-                    It.Is<Exception>(i => i == exception
+                    It.Is<string>(i => i == message
                     )
                 ), Times.Once);
         }
@@ -757,6 +760,27 @@ namespace AWS.Lambda.Powertools.Tracing.Tests
                     It.IsAny<string>(),
                     It.IsAny<Exception>()
                 ), Times.Never);
+        }
+
+        #endregion
+        
+        #region Utilities
+
+        static string GetException(Exception exception)
+        {
+            var message =
+                "Exception type " + exception.GetType() + Environment.NewLine +
+                "Exception message: " + exception.Message + Environment.NewLine +
+                "Stack trace: " + exception.StackTrace + Environment.NewLine;
+            if (exception.InnerException != null)
+            {
+                message += "---BEGIN InnerException--- " + Environment.NewLine +
+                           "Exception type " + exception.InnerException.GetType() + Environment.NewLine +
+                           "Exception message: " + exception.InnerException.Message + Environment.NewLine +
+                           "Stack trace: " + exception.InnerException.StackTrace + Environment.NewLine +
+                           "---END Inner Exception";
+            }
+            return message;
         }
 
         #endregion


### PR DESCRIPTION
Fix Tracing when exception is thrown. Prevent Tracing from throwing InvalidOperationException

> Please provide the issue number

Issue number: 211

## Summary

This issue occurs when:

* Tracing feature was enabled and the setting POWERTOOLS_TRACER_CAPTURE_ERROR was set to true
* If there was an exception not handled or an exception thrown in the code

The following exception would occur

```

  "errorType": "TargetInvocationException",
  "errorMessage": "Exception has been thrown by the target of an invocation.",
  "stackTrace": [
    "at System.RuntimeMethodHandle.InvokeMethod(Object target, Span1& arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)",
    "at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)",
    "at System.Reflection.RuntimePropertyInfo.GetValue(Object obj, BindingFlags invokeAttr, Binder binder, Object[] index, CultureInfo culture)",
    "at System.Reflection.RuntimePropertyInfo.GetValue(Object obj, Object[] index)",
    "at ThirdParty.LitJson.JsonMapper.WriteValue(Object obj, JsonWriter writer, Boolean writer_is_private, Int32 depth) in //sdk/src/Core/ThirdParty/LitJson/JsonMapper.cs:line 836",
    "at ThirdParty.LitJson.JsonMapper.WriteValue(Object obj, JsonWriter writer, Boolean writer_is_private, Int32 depth) in //sdk/src/Core/ThirdParty/LitJson/JsonMapper.cs:line 836",
    "at ThirdParty.LitJson.JsonMapper.WriteValue(Object obj, JsonWriter writer, Boolean writer_is_private, Int32 depth) in //sdk/src/Core/ThirdParty/LitJson/JsonMapper.cs:line 836",
    "at ThirdParty.LitJson.JsonMapper.WriteValue(Object obj, JsonWriter writer, Boolean writer_is_private, Int32 depth) in //sdk/src/Core/ThirdParty/LitJson/JsonMapper.cs:line 767",
    "at ThirdParty.LitJson.JsonMapper.WriteValue(Object obj, JsonWriter writer, Boolean writer_is_private, Int32 depth) in //sdk/src/Core/ThirdParty/LitJson/JsonMapper.cs:line 767",
    "at Amazon.XRay.Recorder.Core.Internal.Emitters.JsonSegmentMarshaller.WriteEntityFields(Entity entity, JsonWriter writer) in //sdk/src/Core/Internal/Emitters/JsonSegmentMarshaller.cs:line 152",
    "at Amazon.XRay.Recorder.Core.Internal.Emitters.JsonSegmentMarshaller.EntityExporter(Entity entity, JsonWriter writer) in //sdk/src/Core/Internal/Emitters/JsonSegmentMarshaller.cs:line 65",
    "at ThirdParty.LitJson.JsonMapper.<>c__DisplayClass38_01.<RegisterExporter>b__0(Object obj, JsonWriter writer) in //sdk/src/Core/ThirdParty/LitJson/JsonMapper.cs:line 919",
    "at ThirdParty.LitJson.JsonMapper.WriteValue(Object obj, JsonWriter writer, Boolean writer_is_private, Int32 depth) in //sdk/src/Core/ThirdParty/LitJson/JsonMapper.cs:line 790",
    "at ThirdParty.LitJson.JsonMapper.ToJson(Object obj) in //sdk/src/Core/ThirdParty/LitJson/JsonMapper.cs:line 851",
    "at Amazon.XRay.Recorder.Core.Internal.Emitters.JsonSegmentMarshaller.Marshall(Entity segment) in //sdk/src/Core/Internal/Emitters/JsonSegmentMarshaller.cs:line 58",
    "at Amazon.XRay.Recorder.Core.Internal.Emitters.UdpSegmentEmitter.Send(Entity segment) in //sdk/src/Core/Internal/Emitters/UdpSegmentEmitter.cs:line 73",
    "at Amazon.XRay.Recorder.Core.Strategies.DefaultStreamingStrategy.Stream(Entity entity, ISegmentEmitter emitter) in //sdk/src/Core/Strategies/DefaultStreamingStrategy.cs:line 80",
    "at Amazon.XRay.Recorder.Core.Strategies.DefaultStreamingStrategy.Stream(Entity entity, ISegmentEmitter emitter) in //sdk/src/Core/Strategies/DefaultStreamingStrategy.cs:line 65",
    "at Amazon.XRay.Recorder.Core.AWSXRayRecorder.EndFacadeSegment() in //sdk/src/Core/AWSXRayRecorder.netcore.cs:line 407",
    "at Amazon.XRay.Recorder.Core.AWSXRayRecorder.ProcessEndSubsegmentInLambdaContext(Nullable1 timestamp) in //sdk/src/Core/AWSXRayRecorder.netcore.cs:line 371",
    "at Amazon.XRay.Recorder.Core.AWSXRayRecorder.EndSubsegment(Nullable1 timestamp) in /_/sdk/src/Core/AWSXRayRecorder.netcore.cs:line 328",
    "at AWS.Lambda.Powertools.Tracing.Internal.XRayRecorder.EndSubsegment()",
    "at AWS.Lambda.Powertools.Tracing.Internal.TracingAspectHandler.OnExit(AspectEventArgs eventArgs)",
    "at AWS.Lambda.Powertools.Common.MethodAspectAttribute.WrapAsync[T](Func`2 target, Object[] args, AspectEventArgs eventArgs)",
    "at lambda_method1(Closure , Stream , ILambdaContext , Stream )",
    "at Amazon.Lambda.RuntimeSupport.Bootstrap.UserCodeLoader.Invoke(Stream lambdaData, ILambdaContext lambdaContext, Stream outStream) in /src/Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeLoader.cs:line 145",
    "at Amazon.Lambda.RuntimeSupport.HandlerWrapper.<>c__DisplayClass8_0.<GetHandlerWrapper>b__0(InvocationRequest invocation) in /src/Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/HandlerWrapper.cs:line 55",
    "at Amazon.Lambda.RuntimeSupport.LambdaBootstrap.InvokeOnceAsync(CancellationToken cancellationToken) in /src/Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs:line 176"
  ],
  "cause": {
    "errorType": "InvalidOperationException",
    "errorMessage": "Method may only be called on a Type for which Type.IsGenericParameter is true.",
    "stackTrace": [
      "at System.RuntimeType.get_DeclaringMethod()"
    ]
  }
```
This exception would be thrown which does not match (hides) the real exception that occurred.

The code responsible to add the exception to the metadata when an exception occurs in our code can be found at AWS.Lambda.Powertools.Tracing/Internal/TracingAspectHandler.cs line 161
And bellow

```
public T OnException<T>(AspectEventArgs eventArgs, Exception exception)
    {
        if (CaptureError())
        {
            var nameSpace = GetNamespace();
            
            _xRayRecorder.AddMetadata
            (
                nameSpace,
                $"{eventArgs.Name} error",
                exception <--- Issue here
            );
        }

        throw exception;
    }
```

The problem occurs when we pass the exception object to AddMetadata which internally cals XRay sdk 
AWSXRayRecorder.Instance.AddMetadata(nameSpace, key, value); 
Although value accepts an object, exception type is not valid in this case due to the type being generic and without a T assigned.

So what exactly is a "Type for which Type.IsGenericParameter is true"
That means it is a generic type argument in an open generic type - i.e. where we haven't picked a T yet; for example:

```
// true
bool isGenParam = typeof(List<>).GetGenericArguments()[0].IsGenericParameter;

// false (T is System.Int32)
bool isGenParam = typeof(List<int>).GetGenericArguments()[0].IsGenericParameter;
```

### Changes

Transform the exception into a string

```
public T OnException<T>(AspectEventArgs eventArgs, Exception exception)
    {
        if (CaptureError())
        {
            var nameSpace = GetNamespace();
            
            var message =
                "Exception type " + exception.GetType() + Environment.NewLine +
                "Exception message: " + exception.Message + Environment.NewLine +
                "Stack trace: " + exception.StackTrace + Environment.NewLine;
            if (exception.InnerException != null)
            {
                message += "---BEGIN InnerException--- " + Environment.NewLine +
                           "Exception type " + exception.InnerException.GetType() + Environment.NewLine +
                           "Exception message: " + exception.InnerException.Message + Environment.NewLine +
                           "Stack trace: " + exception.InnerException.StackTrace + Environment.NewLine +
                           "---END Inner Exception";
            }
            
            _xRayRecorder.AddMetadata
            (
                nameSpace,
                $"{eventArgs.Name} error",
                message
            );
        }

        throw exception;
    }
```

### User experience

This approach works and we can see in the image bellow that the original exception is logged in the Lambda logs and added as Metadata in Xray

![image](https://user-images.githubusercontent.com/999396/227554655-6404defc-8446-4d00-98a9-d6b8b2d2b50f.png)


## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
