### PR TITLE
Feature: Powertools User-Agent for Lambda execution environment

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/IPowertoolsConfigurations.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/IPowertoolsConfigurations.cs
@@ -120,4 +120,10 @@ public interface IPowertoolsConfigurations
     /// <param name="defaultValue">if set to <c>true</c> [default value].</param>
     /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
     bool GetEnvironmentVariableOrDefault(string variable, bool defaultValue);
+    
+    /// <summary>
+    /// Sets the execution Environment Variable (AWS_EXECUTION_ENV)
+    /// </summary>
+    /// <param name="type"></param>
+    void SetExecutionEnvironment<T>(T type);
 }

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/IPowertoolsEnvironment.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/IPowertoolsEnvironment.cs
@@ -1,0 +1,66 @@
+using System;
+
+namespace AWS.Lambda.Powertools.Common;
+
+/// <summary>
+/// 
+/// </summary>
+public interface IPowertoolsEnvironment
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="variableName"></param>
+    /// <returns></returns>
+    string GetEnvironmentVariable(string variableName);
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="variableName"></param>
+    /// <param name="value"></param>
+    void SetEnvironmentVariable(string variableName, string value);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="type"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    string GetAssemblyName<T>(T type);
+    
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="type"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    string GetAssemblyVersion<T>(T type);
+}
+
+/// <inheritdoc />
+public class PowertoolsEnvironment : IPowertoolsEnvironment
+{
+    /// <inheritdoc />
+    public string GetEnvironmentVariable(string variableName)
+    {
+        return Environment.GetEnvironmentVariable(variableName);
+    }
+
+    /// <inheritdoc />
+    public void SetEnvironmentVariable(string variableName, string value)
+    {
+        Environment.SetEnvironmentVariable(variableName, value);
+    }
+
+    /// <inheritdoc />
+    public string GetAssemblyName<T>(T type)
+    {
+        return type.GetType().Assembly.GetName().Name;
+    }
+
+    /// <inheritdoc />
+    public string GetAssemblyVersion<T>(T type)
+    {
+        return type.GetType().Assembly.GetName().Version?.ToString();
+    }
+}

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/IPowertoolsEnvironment.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/IPowertoolsEnvironment.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace AWS.Lambda.Powertools.Common;
 
 /// <summary>
@@ -35,32 +33,4 @@ public interface IPowertoolsEnvironment
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     string GetAssemblyVersion<T>(T type);
-}
-
-/// <inheritdoc />
-public class PowertoolsEnvironment : IPowertoolsEnvironment
-{
-    /// <inheritdoc />
-    public string GetEnvironmentVariable(string variableName)
-    {
-        return Environment.GetEnvironmentVariable(variableName);
-    }
-
-    /// <inheritdoc />
-    public void SetEnvironmentVariable(string variableName, string value)
-    {
-        Environment.SetEnvironmentVariable(variableName, value);
-    }
-
-    /// <inheritdoc />
-    public string GetAssemblyName<T>(T type)
-    {
-        return type.GetType().Assembly.GetName().Name;
-    }
-
-    /// <inheritdoc />
-    public string GetAssemblyVersion<T>(T type)
-    {
-        return type.GetType().Assembly.GetName().Version?.ToString();
-    }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/ISystemWrapper.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/ISystemWrapper.cs
@@ -44,4 +44,17 @@ public interface ISystemWrapper
     /// </summary>
     /// <returns>System.Double.</returns>
     double GetRandom();
+    
+    /// <summary>
+    ///     Sets the environment variable.
+    /// </summary>
+    /// <param name="variable">The variable.</param>
+    /// <param name="value"></param>
+    void SetEnvironmentVariable(string variable, string value);
+    
+    /// <summary>
+    /// Sets the execution Environment Variable (AWS_EXECUTION_ENV)
+    /// </summary>
+    /// <param name="type"></param>
+    void SetExecutionEnvironment<T>(T type);
 }

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsConfigurations.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsConfigurations.cs
@@ -184,4 +184,10 @@ public class PowertoolsConfigurations : IPowertoolsConfigurations
     /// <value><c>true</c> if [tracing is disabled]; otherwise, <c>false</c>.</value>
     public bool TracingDisabled =>
         GetEnvironmentVariableOrDefault(Constants.TracingDisabledEnv, false);
+
+    /// <inheritdoc />
+    public void SetExecutionEnvironment<T>(T type)
+    {
+        _systemWrapper.SetExecutionEnvironment(type);
+    }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsEnvironment.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsEnvironment.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace AWS.Lambda.Powertools.Common;
+
+/// <inheritdoc />
+public class PowertoolsEnvironment : IPowertoolsEnvironment
+{
+    /// <summary>
+    ///     The instance
+    /// </summary>
+    private static IPowertoolsEnvironment _instance;
+    
+    /// <summary>
+    ///     Gets the instance.
+    /// </summary>
+    /// <value>The instance.</value>
+    public static IPowertoolsEnvironment Instance => _instance ??= new PowertoolsEnvironment();
+    
+    /// <inheritdoc />
+    public string GetEnvironmentVariable(string variableName)
+    {
+        return Environment.GetEnvironmentVariable(variableName);
+    }
+
+    /// <inheritdoc />
+    public void SetEnvironmentVariable(string variableName, string value)
+    {
+        Environment.SetEnvironmentVariable(variableName, value);
+    }
+
+    /// <inheritdoc />
+    public string GetAssemblyName<T>(T type)
+    {
+        return type.GetType().Assembly.GetName().Name;
+    }
+
+    /// <inheritdoc />
+    public string GetAssemblyVersion<T>(T type)
+    {
+        return type.GetType().Assembly.GetName().Version?.ToString();
+    }
+}

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsEnvironment.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/PowertoolsEnvironment.cs
@@ -37,6 +37,7 @@ public class PowertoolsEnvironment : IPowertoolsEnvironment
     /// <inheritdoc />
     public string GetAssemblyVersion<T>(T type)
     {
-        return type.GetType().Assembly.GetName().Version?.ToString();
+        var version = type.GetType().Assembly.GetName().Version;
+        return version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : string.Empty;
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/SystemWrapper.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/SystemWrapper.cs
@@ -25,7 +25,7 @@ namespace AWS.Lambda.Powertools.Common;
 /// <seealso cref="ISystemWrapper" />
 public class SystemWrapper : ISystemWrapper
 {
-    private readonly IPowertoolsEnvironment _powertoolsEnvironment;
+    private static IPowertoolsEnvironment _powertoolsEnvironment;
 
     /// <summary>
     ///     The instance
@@ -45,7 +45,7 @@ public class SystemWrapper : ISystemWrapper
     ///     Gets the instance.
     /// </summary>
     /// <value>The instance.</value>
-    public static ISystemWrapper Instance => _instance ??= new SystemWrapper(new PowertoolsEnvironment());
+    public static ISystemWrapper Instance => _instance ??= new SystemWrapper(PowertoolsEnvironment.Instance);
 
     /// <summary>
     ///     Gets the environment variable.

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/SystemWrapper.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/SystemWrapper.cs
@@ -100,14 +100,34 @@ public class SystemWrapper : ISystemWrapper
         // If there is an existing execution environment variable add the annotations package as a suffix.
         if(!string.IsNullOrEmpty(GetEnvironmentVariable(envName)))
         {
-            envValue.Append($"{GetEnvironmentVariable(envName)}_");
+            envValue.Append($"{GetEnvironmentVariable(envName)} ");
         }
 
         var assemblyVersion = _powertoolsEnvironment.GetAssemblyVersion(type);
         var assemblyName =_powertoolsEnvironment.GetAssemblyName(type);
 
-        envValue.Append($"{assemblyName}_{assemblyVersion}");
+        envValue.Append($"{ParseAssemblyName(assemblyName)}/{assemblyVersion}");
 
         SetEnvironmentVariable(envName, envValue.ToString());
+    }
+
+    /// <summary>
+    /// Parsing the name to conform with the required naming convention for the UserAgent header (PTFeature/Name/Version)
+    /// Fallback to Assembly Name on exception
+    /// </summary>
+    /// <param name="assemblyName"></param>
+    /// <returns></returns>
+    private string ParseAssemblyName(string assemblyName)
+    {
+        try
+        {
+            var parsedName = assemblyName.Substring(assemblyName.LastIndexOf(".", StringComparison.Ordinal)+1);
+            return $"PTFeature/{parsedName}";
+        }
+        catch
+        {
+            //NOOP
+        }
+        return $"PTFeature/{assemblyName}";
     }
 }

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
@@ -76,6 +76,8 @@ internal sealed class PowertoolsLogger : ILogger
     {
         (_name, _powertoolsConfigurations, _systemWrapper, _getCurrentConfig) = (name,
             powertoolsConfigurations, systemWrapper, getCurrentConfig);
+        
+        systemWrapper.SetExecutionEnvironment(this);
     }
 
     /// <summary>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
@@ -71,6 +71,8 @@ public class Metrics : IMetrics
         _raiseOnEmptyMetrics = raiseOnEmptyMetrics;
         _captureColdStartEnabled = captureColdStartEnabled;
         _context = InitializeContext(nameSpace, service, null);
+        
+        _powertoolsConfigurations.SetExecutionEnvironment(this);
     }
 
     /// <summary>

--- a/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsConfigurationsTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsConfigurationsTest.cs
@@ -639,6 +639,30 @@ namespace AWS.Lambda.Powertools.Common.Tests
             Assert.True(result);
         }
         
+        [Fact]
+        public void Set_Lambda_Execution_Context()
+        {
+            // Arrange
+            var systemWrapper = new Mock<ISystemWrapper>();
+
+            // systemWrapper.Setup(c =>
+            //     c.SetExecutionEnvironment(GetType())
+            // );
+            
+            var configurations = new PowertoolsConfigurations(systemWrapper.Object);
+            
+            // Act
+            configurations.SetExecutionEnvironment(typeof(PowertoolsConfigurations));
+
+            // Assert
+            // method with correct type was called
+            systemWrapper.Verify(v =>
+                v.SetExecutionEnvironment(
+                    It.Is<Type>(i => i == typeof(PowertoolsConfigurations))
+                ), Times.Once);
+            
+        }
+        
         #endregion
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsEnvironmentTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsEnvironmentTest.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using Moq;
+using Xunit;
+
+namespace AWS.Lambda.Powertools.Common.Tests;
+
+public class PowertoolsEnvironmentTest
+{
+    [Fact]
+    public void Set_Execution_Environment()
+    {
+        // Arrange
+        var systemWrapper = new SystemWrapper(new MockEnvironment());
+        
+        // Act
+        systemWrapper.SetExecutionEnvironment(this);
+
+        // Assert
+        Assert.Equal("Lambda_Powertools_1.0.0", systemWrapper.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
+    }
+    
+    [Fact]
+    public void Set_Execution_Environment_WhenEnvironmentHasValue()
+    {
+        // Arrange
+        var systemWrapper = new SystemWrapper(new MockEnvironment());
+        
+        systemWrapper.SetEnvironmentVariable("AWS_EXECUTION_ENV", "ExistingValue");
+        
+        // Act
+        systemWrapper.SetExecutionEnvironment(this);
+
+        // Assert
+        Assert.Equal("ExistingValue_Lambda_Powertools_1.0.0", systemWrapper.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
+    }
+}
+
+class MockEnvironment : IPowertoolsEnvironment
+{
+    private readonly Dictionary<string, string> _mockEnvironment = new();
+    
+    public string GetEnvironmentVariable(string variableName)
+    {
+        return _mockEnvironment.TryGetValue(variableName, out var value) ? value : null;
+    }
+
+    public void SetEnvironmentVariable(string variableName, string value)
+    {
+        // Check for entry not existing and add to dictionary
+        _mockEnvironment[variableName] = value;
+    }
+
+    public string GetAssemblyName<T>(T type)
+    {
+        return "Lambda_Powertools";
+    }
+
+    public string GetAssemblyVersion<T>(T type)
+    {
+        return "1.0.0";
+    }
+}

--- a/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsEnvironmentTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsEnvironmentTest.cs
@@ -36,6 +36,9 @@ public class PowertoolsEnvironmentTest
     }
 }
 
+/// <summary>
+/// Fake Environment for testing
+/// </summary>
 class MockEnvironment : IPowertoolsEnvironment
 {
     private readonly Dictionary<string, string> _mockEnvironment = new();

--- a/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsEnvironmentTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Common.Tests/Core/PowertoolsEnvironmentTest.cs
@@ -1,11 +1,10 @@
 using System;
 using System.Collections.Generic;
-using Moq;
 using Xunit;
 
 namespace AWS.Lambda.Powertools.Common.Tests;
 
-public class PowertoolsEnvironmentTest
+public class PowertoolsEnvironmentTest : IDisposable
 {
     [Fact]
     public void Set_Execution_Environment()
@@ -17,7 +16,7 @@ public class PowertoolsEnvironmentTest
         systemWrapper.SetExecutionEnvironment(this);
 
         // Assert
-        Assert.Equal("Lambda_Powertools_1.0.0", systemWrapper.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
+        Assert.Equal("PTFeature/Fake/1.0.0", systemWrapper.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
     }
     
     [Fact]
@@ -26,13 +25,61 @@ public class PowertoolsEnvironmentTest
         // Arrange
         var systemWrapper = new SystemWrapper(new MockEnvironment());
         
-        systemWrapper.SetEnvironmentVariable("AWS_EXECUTION_ENV", "ExistingValue");
+        systemWrapper.SetEnvironmentVariable("AWS_EXECUTION_ENV", "ExistingValuesInUserAgent");
         
         // Act
         systemWrapper.SetExecutionEnvironment(this);
 
         // Assert
-        Assert.Equal("ExistingValue_Lambda_Powertools_1.0.0", systemWrapper.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
+        Assert.Equal("ExistingValuesInUserAgent PTFeature/Fake/1.0.0", systemWrapper.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
+    }
+    
+    [Fact]
+    public void Set_Multiple_Execution_Environment()
+    {
+        // Arrange
+        var systemWrapper = new SystemWrapper(new MockEnvironment());
+        
+        // Act
+        systemWrapper.SetExecutionEnvironment(this);
+        systemWrapper.SetExecutionEnvironment(this);
+
+        // Assert
+        Assert.Equal("PTFeature/Fake/1.0.0 PTFeature/Fake/1.0.0", systemWrapper.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
+    }
+    
+    [Fact]
+    public void Set_Execution_Real_Environment()
+    {
+        // Arrange
+        var systemWrapper = new SystemWrapper(new PowertoolsEnvironment());
+        
+        // Act
+        systemWrapper.SetExecutionEnvironment(this);
+
+        // Assert
+        Assert.Equal("PTFeature/Tests/1.0.0", systemWrapper.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
+    }
+    
+    [Fact]
+    public void Set_Execution_Real_Environment_Multiple()
+    {
+        // Arrange
+        var systemWrapper = new SystemWrapper(new PowertoolsEnvironment());
+        
+        // Act
+        systemWrapper.SetExecutionEnvironment(this);
+        systemWrapper.SetExecutionEnvironment(this);
+
+        // Assert
+        Assert.Equal("PTFeature/Tests/1.0.0 PTFeature/Tests/1.0.0", systemWrapper.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
+    }
+
+    public void Dispose()
+    {
+        //Do cleanup actions here
+        
+        Environment.SetEnvironmentVariable("AWS_EXECUTION_ENV", null);
     }
 }
 
@@ -56,7 +103,7 @@ class MockEnvironment : IPowertoolsEnvironment
 
     public string GetAssemblyName<T>(T type)
     {
-        return "Lambda_Powertools";
+        return "AWS.Lambda.Powertools.Fake";
     }
 
     public string GetAssemblyVersion<T>(T type)

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
@@ -1220,5 +1220,41 @@ namespace AWS.Lambda.Powertools.Logging.Tests
                     )
                 ), Times.Once);
         }
+        
+        [Fact]
+        public void Log_Set_Execution_Environment_Context()
+        {
+            // Arrange
+            var loggerName = Guid.NewGuid().ToString();
+            var assemblyName = "LambdaPowertools";
+            var assemblyVersion = "1.0.0";
+            
+            var configurations = new Mock<IPowertoolsConfigurations>();
+
+            var env = new Mock<IPowertoolsEnvironment>();
+            env.Setup(x => x.GetAssemblyName(It.IsAny<PowertoolsLogger>())).Returns(assemblyName);
+            env.Setup(x => x.GetAssemblyVersion(It.IsAny<PowertoolsLogger>())).Returns(assemblyVersion);
+
+            var systemWrapper = new SystemWrapper(env.Object);
+            
+            var logger = new PowertoolsLogger(loggerName,configurations.Object, systemWrapper, () => 
+                new LoggerConfiguration
+                {
+                    Service = null,
+                    MinimumLevel = null
+                });
+            logger.LogInformation("Test");
+
+            // Assert
+            env.Verify(v =>
+                v.SetEnvironmentVariable(
+                    "AWS_EXECUTION_ENV", $"{assemblyName}_{assemblyVersion}"
+                ), Times.Once);
+            
+            env.Verify(v =>
+                v.GetEnvironmentVariable(
+                    "AWS_EXECUTION_ENV"
+                ), Times.Once);
+        }
     }
 }

--- a/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Logging.Tests/PowertoolsLoggerTest.cs
@@ -1226,7 +1226,7 @@ namespace AWS.Lambda.Powertools.Logging.Tests
         {
             // Arrange
             var loggerName = Guid.NewGuid().ToString();
-            var assemblyName = "LambdaPowertools";
+            var assemblyName = "AWS.Lambda.Powertools.Logger";
             var assemblyVersion = "1.0.0";
             
             var configurations = new Mock<IPowertoolsConfigurations>();
@@ -1248,7 +1248,7 @@ namespace AWS.Lambda.Powertools.Logging.Tests
             // Assert
             env.Verify(v =>
                 v.SetEnvironmentVariable(
-                    "AWS_EXECUTION_ENV", $"{assemblyName}_{assemblyVersion}"
+                    "AWS_EXECUTION_ENV", $"PTFeature/Logger/{assemblyVersion}"
                 ), Times.Once);
             
             env.Verify(v =>

--- a/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/MetricsTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Metrics.Tests/MetricsTests.cs
@@ -1,0 +1,36 @@
+using AWS.Lambda.Powertools.Common;
+using Moq;
+using Xunit;
+
+namespace AWS.Lambda.Powertools.Metrics.Tests;
+
+[Collection("Sequential")]
+public class MetricsTests
+{
+    [Fact]
+    public void Metrics_Set_Execution_Environment_Context()
+    {
+        // Arrange
+        var assemblyName = "AWS.Lambda.Powertools.Metrics";
+        var assemblyVersion = "1.0.0";
+            
+        var env = new Mock<IPowertoolsEnvironment>();
+        env.Setup(x => x.GetAssemblyName(It.IsAny<Metrics>())).Returns(assemblyName);
+        env.Setup(x => x.GetAssemblyVersion(It.IsAny<Metrics>())).Returns(assemblyVersion);
+    
+        var conf = new PowertoolsConfigurations(new SystemWrapper(env.Object));
+    
+        var metrics = new Metrics(conf);
+        
+        // Assert
+        env.Verify(v =>
+            v.SetEnvironmentVariable(
+                "AWS_EXECUTION_ENV", $"PTFeature/Metrics/{assemblyVersion}"
+            ), Times.Once);
+            
+        env.Verify(v =>
+            v.GetEnvironmentVariable(
+                "AWS_EXECUTION_ENV"
+            ), Times.Once);
+    }
+}

--- a/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/XRayRecorderTests.cs
+++ b/libraries/tests/AWS.Lambda.Powertools.Tracing.Tests/XRayRecorderTests.cs
@@ -1,0 +1,306 @@
+using System;
+using Amazon.XRay.Recorder.Core;
+using Amazon.XRay.Recorder.Core.Internal.Entities;
+using AWS.Lambda.Powertools.Common;
+using AWS.Lambda.Powertools.Tracing.Internal;
+using Moq;
+using Xunit;
+
+namespace AWS.Lambda.Powertools.Tracing.Tests;
+
+public class XRayRecorderTests
+{
+    [Fact]
+    public void Tracing_Set_Execution_Environment_Context()
+    {
+        // Arrange
+        var assemblyName = "AWS.Lambda.Powertools.Tracing";
+        var assemblyVersion = "1.0.0";
+        
+        var env = new Mock<IPowertoolsEnvironment>();
+        env.Setup(x => x.GetAssemblyName(It.IsAny<XRayRecorder>())).Returns(assemblyName);
+        env.Setup(x => x.GetAssemblyVersion(It.IsAny<XRayRecorder>())).Returns(assemblyVersion);
+
+        var conf = new PowertoolsConfigurations(new SystemWrapper(env.Object));
+        var awsXray = new Mock<IAWSXRayRecorder>();
+        
+        // Act
+        var xRayRecorder = new XRayRecorder(awsXray.Object, conf);
+
+        // Assert
+        env.Verify(v =>
+            v.SetEnvironmentVariable(
+                "AWS_EXECUTION_ENV", $"PTFeature/Tracing/{assemblyVersion}"
+            ), Times.Once);
+            
+        env.Verify(v =>
+            v.GetEnvironmentVariable(
+                "AWS_EXECUTION_ENV"
+            ), Times.Once);
+        
+        Assert.NotNull(xRayRecorder);
+    }
+    
+    [Fact]
+    public void Tracing_Instance()
+    {
+        // Arrange
+        var conf = new Mock<IPowertoolsConfigurations>();
+        var awsXray = new Mock<IAWSXRayRecorder>();
+    
+        // Act
+        
+        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
+        
+        // Assert
+        Assert.Equal(tracing, XRayRecorder.Instance);
+    }
+    
+    [Fact]
+    public void Tracing_Being_Subsegment()
+    {
+        // Arrange
+        var conf = new Mock<IPowertoolsConfigurations>();
+        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
+        
+        var awsXray = new Mock<IAWSXRayRecorder>();
+        
+        // Act
+        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
+    
+        tracing.BeginSubsegment("test");
+        
+        // Assert
+        awsXray.Verify(v =>
+            v.BeginSubsegment("test", null
+            ), Times.Once);
+    }
+    
+    [Fact]
+    public void Tracing_Set_Namespace()
+    {
+        // Arrange
+        var conf = new Mock<IPowertoolsConfigurations>();
+        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
+        
+        var awsXray = new Mock<IAWSXRayRecorder>();
+        
+        // Act
+        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
+    
+        tracing.SetNamespace("test");
+        
+        // Assert
+        awsXray.Verify(v =>
+            v.SetNamespace("test"
+            ), Times.Once);
+    }
+    
+    [Fact]
+    public void Tracing_Add_Annotation()
+    {
+        // Arrange
+        var conf = new Mock<IPowertoolsConfigurations>();
+        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
+        
+        var awsXray = new Mock<IAWSXRayRecorder>();
+        
+        // Act
+        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
+    
+        tracing.AddAnnotation("key", "value");
+        
+        // Assert
+        awsXray.Verify(v =>
+            v.AddAnnotation("key", "value"
+            ), Times.Once);
+    }
+    
+    [Fact]
+    public void Tracing_Add_Metadata()
+    {
+        // Arrange
+        var conf = new Mock<IPowertoolsConfigurations>();
+        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
+        
+        var awsXray = new Mock<IAWSXRayRecorder>();
+        
+        // Act
+        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
+    
+        tracing.AddMetadata("nameSpace","key", "value");
+        
+        // Assert
+        awsXray.Verify(v =>
+            v.AddMetadata("nameSpace","key", "value"
+            ), Times.Once);
+    }
+    
+    [Fact]
+    public void Tracing_End_Subsegment()
+    {
+        // Arrange
+        var conf = new Mock<IPowertoolsConfigurations>();
+        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
+        
+        var awsXray = new Mock<IAWSXRayRecorder>();
+        
+        // Act
+        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
+    
+        tracing.EndSubsegment();
+        
+        // Assert
+        awsXray.Verify(v =>
+            v.EndSubsegment(null), Times.Once);
+    }
+    
+    [Fact]
+    public void Tracing_Get_Entity_In_Lambda_Environment()
+    {
+        // Arrange
+        var conf = new Mock<IPowertoolsConfigurations>();
+        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
+        
+        var awsXray = new Mock<IAWSXRayRecorder>();
+        awsXray.Setup(x => x.TraceContext.GetEntity()).Returns(new Subsegment("root"));
+        
+        // Act
+        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
+    
+        tracing.GetEntity();
+        
+        // Assert
+        awsXray.Verify(v =>
+            v.TraceContext.GetEntity(), Times.Once);
+    }
+    
+    [Fact]
+    public void Tracing_Get_Entity_Outside_Lambda_Environment()
+    {
+        // Arrange
+        var conf = new Mock<IPowertoolsConfigurations>();
+        conf.Setup(c => c.IsLambdaEnvironment).Returns(false);
+        
+        var awsXray = new Mock<IAWSXRayRecorder>();
+        
+        // Act
+        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
+    
+        var entity = tracing.GetEntity();
+        
+        // Assert
+        Assert.Equivalent("Root",entity.Name);
+    }
+    
+    [Fact]
+    public void Tracing_Set_Entity()
+    {
+        // Arrange
+        var conf = new Mock<IPowertoolsConfigurations>();
+        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
+
+        var segment = new Segment("test");
+        
+        var awsXray = new Mock<IAWSXRayRecorder>();
+        awsXray.Setup(x => x.TraceContext.SetEntity(segment));
+        
+        // Act
+        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
+    
+        tracing.SetEntity(segment);
+        
+        // Assert
+        awsXray.Verify(v =>
+            v.TraceContext.SetEntity(segment), Times.Once);
+    }
+    
+    [Fact]
+    public void Tracing_Add_Exception()
+    {
+        // Arrange
+        var conf = new Mock<IPowertoolsConfigurations>();
+        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
+
+        var ex = new ArgumentException("test");
+        
+        var awsXray = new Mock<IAWSXRayRecorder>();
+        awsXray.Setup(x => x.AddException(ex));
+        
+        // Act
+        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
+    
+        tracing.AddException(ex);
+        
+        // Assert
+        awsXray.Verify(v =>
+            v.AddException(ex), Times.Once);
+    }
+    
+    [Fact]
+    public void Tracing_Add_Http_Information()
+    {
+        // Arrange
+        var conf = new Mock<IPowertoolsConfigurations>();
+        conf.Setup(c => c.IsLambdaEnvironment).Returns(true);
+
+        var key = "key";
+        var value = "value";
+        
+        var awsXray = new Mock<IAWSXRayRecorder>();
+        awsXray.Setup(x => x.AddHttpInformation(key,value));
+        
+        // Act
+        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
+    
+        tracing.AddHttpInformation(key,value);
+        
+        // Assert
+        awsXray.Verify(v =>
+            v.AddHttpInformation(key,value), Times.Once);
+    }
+    
+    [Fact]
+    public void Tracing_All_When_Outside_Lambda()
+    {
+        // Arrange
+        var conf = new Mock<IPowertoolsConfigurations>();
+        conf.Setup(c => c.IsLambdaEnvironment).Returns(false);
+
+        var awsXray = new Mock<IAWSXRayRecorder>();
+        var tracing = new XRayRecorder(awsXray.Object, conf.Object);
+        
+        // Act
+
+        tracing.AddHttpInformation(It.IsAny<string>(),It.IsAny<string>());
+        tracing.AddException(It.IsAny<Exception>());
+        tracing.SetEntity(It.IsAny<Entity>());
+        tracing.EndSubsegment();
+        tracing.AddMetadata(It.IsAny<string>(),It.IsAny<string>(), It.IsAny<string>());
+        tracing.AddAnnotation(It.IsAny<string>(),It.IsAny<string>());
+        tracing.SetNamespace(It.IsAny<string>());
+        tracing.BeginSubsegment(It.IsAny<string>());
+        
+        // Assert
+        awsXray.Verify(v =>
+            v.AddHttpInformation(It.IsAny<string>(),It.IsAny<string>()), Times.Never);
+        awsXray.Verify(v =>
+            v.AddException(It.IsAny<Exception>()), Times.Never);
+        awsXray.Verify(v =>
+            v.TraceContext.SetEntity(It.IsAny<Entity>()), Times.Never);
+        awsXray.Verify(v =>
+            v.EndSubsegment(null), Times.Never);
+        awsXray.Verify(v =>
+            v.AddMetadata(It.IsAny<string>(),It.IsAny<string>(), It.IsAny<string>()
+            ), Times.Never);
+        awsXray.Verify(v =>
+            v.AddAnnotation(It.IsAny<string>(),It.IsAny<string>()
+            ), Times.Never);
+        awsXray.Verify(v =>
+            v.SetNamespace(It.IsAny<string>()
+            ), Times.Never);
+        awsXray.Verify(v =>
+            v.BeginSubsegment(It.IsAny<string>(), null
+            ), Times.Never);
+    }
+}


### PR DESCRIPTION

Issue number: #213 

## Summary

Update the execution environment so that the appropriate metadata can be attached to the user agent string during service calls via the AWS SDK for .NET

### Changes

- Add method to set context in PowertoolsConfigurations.cs. 
- New PowertoolsEnvironment interface as a facade for System.Environment. Makes it testable
- Context naming convention for Utilities ``PTFeature/Name/Version``
- Call SetExecutionEnvironment from Metrics, Tracing and Logging utilities
- This method is called with the Type and uses reflection to get the Name and Version of the calling Assembly
- Many more tests

New method to set the execution environment in the `AWS.Lambda.Powertools.Common`  project

``` csharp
public void SetExecutionEnvironment<T>(T type)
{
    const string envName = "AWS_EXECUTION_ENV";

    var envValue = new StringBuilder();

    // If there is an existing execution environment variable add the annotations package as a suffix.
    if(!string.IsNullOrEmpty(GetEnvironmentVariable(envName)))
    {
        envValue.Append($"{GetEnvironmentVariable(envName)} ");
    }

    var assemblyVersion = _powertoolsEnvironment.GetAssemblyVersion(type);
    var assemblyName =_powertoolsEnvironment.GetAssemblyName(type);

    envValue.Append($"{ParseAssemblyName(assemblyName)}/{assemblyVersion}");

    SetEnvironmentVariable(envName, envValue.ToString());
}
```
Each Utility will have to Set the execution context

``` csharp
_powertoolsConfigurations.SetExecutionEnvironment(this);
```

### User experience

User-Agent header is updated and includes the Utilities used in the request to an AWS service using AWS SDK

![image](https://user-images.githubusercontent.com/999396/233706077-559d9544-a78e-4df2-a2da-1866d954e0c6.png)


## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
