### PR TITLE
chore: rename project to Powertools for AWS Lambda (.NET)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,7 +48,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: AWS Lambda Powertools for .NET version
+      label: Powertools for AWS Lambda (.NET) version
       placeholder: "latest, 1.25.6"
       value: latest
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,12 +1,12 @@
 name: Feature request
-description: Suggest an idea for Lambda Powertools
+description: Suggest an idea for Powertools for AWS Lambda (.NET)
 title: "Feature request: TITLE"
 labels: ["feature-request", "triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to suggest an idea to the Lambda Powertools project.
+        Thank you for taking the time to suggest an idea to the Powertools for AWS Lambda (.NET) project.
 
         *Future readers*: Please react with 👍 and your use case to help us understand customer demand.
   - type: textarea
@@ -36,9 +36,9 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: This feature request meets [Lambda Powertools Tenets](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
+        - label: This feature request meets [Powertools for AWS Lambda (.NET) Tenets](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
           required: true
-        - label: Should this be considered in other Lambda Powertools languages? i.e. [Python](https://github.com/awslabs/aws-lambda-powertools-python), [Java](https://github.com/awslabs/aws-lambda-powertools-java/), and [TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript/)
+        - label: Should this be considered in other Powertools for AWS Lambda languages? i.e. [Python](https://github.com/awslabs/aws-lambda-powertools-python), [Java](https://github.com/awslabs/aws-lambda-powertools-java/), and [TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript/)
           required: false
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -60,7 +60,7 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: This request meets [Lambda Powertools Tenets](https://awslabs.github.io/aws-lambda-powertools-dotnet/latest/#tenets)
+        - label: This request meets [Powertools for AWS Lambda (.NET) Tenets](https://awslabs.github.io/aws-lambda-powertools-dotnet/latest/#tenets)
           required: true
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -15,7 +15,7 @@ body:
   - type: dropdown
     id: area
     attributes:
-      label: Which AWS Lambda Powertools utility does this relate to?
+      label: Which Powertools for AWS Lambda (.NET) utility does this relate to?
       options:
         - Tracing
         - Logging
@@ -79,9 +79,9 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: This feature request meets [Lambda Powertools Tenets](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets/)
+        - label: This feature request meets [Powertools for AWS Lambda (.NET) Tenets](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets/)
           required: true
-        - label: Should this be considered in other Lambda Powertools languages? i.e. [Python](https://github.com/awslabs/aws-lambda-powertools-python), [Java](https://github.com/awslabs/aws-lambda-powertools-java/), and [TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript/)
+        - label: Should this be considered in other Powertools for AWS Lambda (.NET) languages? i.e. [Python](https://github.com/awslabs/aws-lambda-powertools-python), [Java](https://github.com/awslabs/aws-lambda-powertools-java/), and [TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript/)
           required: false
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/share_your_work.yml
+++ b/.github/ISSUE_TEMPLATE/share_your_work.yml
@@ -1,5 +1,5 @@
 name: I Made This (showcase your work)
-description: Share what you did with Powertools 💞💞. Blog post, workshops, presentation, sample apps, etc.
+description: Share what you did with Powertools for AWS Lambda (.NET) 💞💞. Blog post, workshops, presentation, sample apps, etc.
 title: "[I Made This]: <TITLE>"
 labels: ["community-content"]
 body:
@@ -13,7 +13,7 @@ body:
       description: |
         Please share the original link to your material.
 
-        *Note: Short links will be expanded when added to Powertools documentation*
+        *Note: Short links will be expanded when added to Powertools for AWS Lambda (.NET) documentation*
     validations:
       required: true
   - type: textarea
@@ -44,7 +44,7 @@ body:
       description: |
         Any notes you might want to share with us related to this material.
 
-        *Note: These notes are explicitly to Powertools maintainers. It will not be added to the community resources page.*
+        *Note: These notes are explicitly to Powertools for AWS Lambda (.NET) maintainers. It will not be added to the community resources page.*
     validations:
       required: false
   - type: checkboxes
@@ -52,5 +52,5 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: I understand this content may be removed from Powertools documentation if it doesn't conform with the [Code of Conduct](https://aws.github.io/code-of-conduct)
+        - label: I understand this content may be removed from Powertools for AWS Lambda (.NET) documentation if it doesn't conform with the [Code of Conduct](https://aws.github.io/code-of-conduct)
           required: true

--- a/.github/ISSUE_TEMPLATE/support_powertools.yml
+++ b/.github/ISSUE_TEMPLATE/support_powertools.yml
@@ -1,6 +1,6 @@
-name: Support Lambda Powertools (become a reference)
-description: Add your organization's name or logo to the Lambda Powertools documentation
-title: "[Support Lambda Powertools]: <your organization name>"
+name: Support Powertools for AWS Lambda (.NET) (become a reference)
+description: Add your organization's name or logo to the Powertools for AWS Lambda (.NET) documentation
+title: "[Support Powertools for AWS Lambda (.NET)]: <your organization name>"
 labels: ["customer-reference"]
 body:
   - type: markdown
@@ -42,13 +42,13 @@ body:
     id: use_case
     attributes:
       label: (Optional) Use case
-      description: How are you using Lambda Powertools today? *features, etc.*
+      description: How are you using Powertools for AWS Lambda (.NET) today? *features, etc.*
     validations:
       required: false
   - type: checkboxes
     id: other_languages
     attributes:
-      label: Also using other Lambda Powertools languages?
+      label: Also using other Powertools for AWS Lambda (.NET) languages?
       options:
         - label: Python
           required: false
@@ -59,6 +59,6 @@ body:
   - type: markdown
     attributes:
       value: |
-        *By raising a Support Lambda Powertools issue, you are granting AWS permission to use your company's name (and/or logo) for the limited purpose described here. You are also confirming that you have authority to grant such permission.*
+        *By raising a Support Powertools for AWS Lambda (.NET) issue, you are granting AWS permission to use your company's name (and/or logo) for the limited purpose described here. You are also confirming that you have authority to grant such permission.*
 
         *You can opt-out at any time by commenting or reopening this issue.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [1.1.0] - 2023-05-05
 ## Maintenance
 
-* add Lambda Powertools for Python in issue templates
+* add Lambda Powertools for AWS Lambda (Python) in issue templates
 * add workflow to dispatch analytics fetching
 * **ci:** add workflow to dispatch analytics fetching
 
@@ -76,7 +76,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## Documentation
 
-* **home:** update powertools definition
+* **home:** update Powertools for AWS Lambda (.NET) definition
 
 ## Maintenance
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -75,7 +75,7 @@ These are the most common labels used by maintainers to triage issues, pull requ
 | breaking-change        | Changes that will cause customer impact and need careful triage  |                                                                 |
 | do-not-merge           | PRs that are blocked for varying reasons                         | Timeline is uncertain                                           |
 | tests                  | PRs that add or change tests                                     | PR automation                                                   |
-| `area/<utility>`       | PRs related to a Powertools utility, e.g. `logging`, `tracing`   | PR automation                                                   |
+| `area/<utility>`       | PRs related to a Powertools for AWS Lambda (.NET) utility, e.g. `logging`, `tracing`   | PR automation                                                   |
 | feature                | New features or minor changes                                    | PR/Release automation                                           |
 | dependencies           | Changes that touch dependencies, e.g. Dependabot, etc.           | PR/ automation                                                  |
 | github-actions         | Changes in GitHub workflows                                      | PR automation                                                   |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# AWS Lambda Powertools for .NET
+# Powertools for AWS Lambda (.NET)
 
 ![aws provider](https://img.shields.io/badge/provider-AWS-orange?logo=amazon-aws&color=ff9900)
 [![Build](https://github.com/awslabs/aws-lambda-powertools-dotnet/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/awslabs/aws-lambda-powertools-dotnet/actions/workflows/build.yml)
 [![Join our Discord](https://dcbadge.vercel.app/api/server/B8zZKbbyET)](https://discord.gg/B8zZKbbyET)
 
-Powertools is a developer toolkit to implement Serverless [best practices and increase developer velocity](https://awslabs.github.io/aws-lambda-powertools-dotnet/#features).
+Powertools for AWS Lambda (.NET) is a developer toolkit to implement Serverless [best practices and increase developer velocity](https://awslabs.github.io/aws-lambda-powertools-dotnet/#features).
 
 **[📜 Documentation](https://awslabs.github.io/aws-lambda-powertools-dotnet/)** | **[NuGet](https://www.nuget.org/)** | **[Roadmap](https://github.com/awslabs/aws-lambda-powertools-roadmap/projects/1)** | **[Examples](#examples)**
 
@@ -12,7 +12,7 @@ Powertools is a developer toolkit to implement Serverless [best practices and in
 
 ## Features
 
-Lambda Powertools provides three core utilities:
+Powertools for AWS Lambda (.NET) provides three core utilities:
 
 * **[Logging](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/)** - provides a custom logger class that outputs structured JSON. It allows you to pass in strings or more complex objects, and will take care of serializing the log output. Common use cases—such as logging the Lambda event payload and capturing cold start information—are handled for you, including appending custom keys to the logger at anytime.
 
@@ -24,7 +24,7 @@ Lambda Powertools provides three core utilities:
 
 ### Installation
 
-The AWS Lambda Powertools for .NET utilities (.NET 6) are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*){target="_blank"} or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
+The Powertools for AWS Lambda (.NET) utilities (.NET 6) are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*){target="_blank"} or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
 
 * [AWS.Lambda.Powertools.Logging](https://www.nuget.org/packages?q=AWS.Lambda.Powertools.Logging):
 
@@ -50,18 +50,18 @@ We have provided examples focused specifically on each of the utilities. Each so
 * **[Metrics example](examples/Metrics/)**
 * **[Tracing example](examples/Tracing/)**
 
-## Other members of the AWS Lambda Powertools family
+## Other members of the Powertools for AWS Lambda family
 
-Not using .NET? No problem, we have you covered. Here are the other members of the AWS Lambda Powertools family:
+Not using .NET? No problem, we have you covered. Here are the other members of the Powertools for AWS Lambda family:
 
-* [AWS Lambda Powertools for Python](https://github.com/awslabs/aws-lambda-powertools-python)
-* [AWS Lambda Powertools for Java](https://github.com/awslabs/aws-lambda-powertools-java)
-* [AWS Lambda Powertools for TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript)
+* [Powertools for AWS Lambda (Python)](https://github.com/awslabs/aws-lambda-powertools-python)
+* [Powertools for AWS Lambda (Java)](https://github.com/awslabs/aws-lambda-powertools-java)
+* [Powertools for AWS Lambda (TypeScript)](https://github.com/awslabs/aws-lambda-powertools-typescript)
 
 ## Credits
 
 * Structured logging initial implementation from [aws-lambda-logging](https://gitlab.com/hadrien/aws_lambda_logging)
-* Powertools idea [DAZN Powertools](https://github.com/getndazn/dazn-lambda-powertools/)
+* Powertools for AWS Lambda (.NET) idea [DAZN Powertools](https://github.com/getndazn/dazn-lambda-powertools/)
 
 ## 👋 Contributing
 
@@ -71,7 +71,7 @@ We welcome contributions from developers of all levels to our open-source projec
 
 ## Connect
 
-* **AWS Lambda Powertools on Discord**: `#dotnet` - **[Invite link](https://discord.gg/B8zZKbbyET)**
+* **Powertools for AWS Lambda on Discord**: `#dotnet` - **[Invite link](https://discord.gg/B8zZKbbyET)**
 * **Email**: <aws-lambda-powertools-feedback@amazon.com>
 
 ## License

--- a/apidocs/docfx.json
+++ b/apidocs/docfx.json
@@ -33,13 +33,13 @@
     "dest": "_site",
     "globalMetadataFiles": [],
     "globalMetadata": {
-      "_appTitle": "AWS Lambda Powertools for .NET",
+      "_appTitle": "Powertools for AWS Lambda (.NET)",
       "_appFaviconPath": "images/favicon.ico",
       "_appLogoPath": "images/img.svg",
       "_enableNewTab": true,
       "_disableContribution": true,
       "_enableSearch": "true",
-      "_appFooter": "AWS Lambda Powertools for .NET API Documentation"
+      "_appFooter": "Powertools for AWS Lambda (.NET) API Documentation"
     },
     "fileMetadataFiles": [],
     "template": ["default", "templates/material"],

--- a/apidocs/index.md
+++ b/apidocs/index.md
@@ -1,14 +1,14 @@
-# AWS Lambda Powertools for .NET API
+# Powertools for AWS Lambda (.NET) API
 
-Welcome to the **AWS Lambda Powertools for .NET API** reference. This documentation contains the API details for all supported utilities.
+Welcome to the **Powertools for AWS Lambda (.NET) API** reference. This documentation contains the API details for all supported utilities.
 
 To get started use the `API Documentaion` menu on the navigation bar, or search for specific keywords on the search box on top-right corner of your screen.
 
 > [!NOTE]
-> Are you looking for documentation on how to use AWS Lambda Powertools for .NET utilities and code samples?
+> Are you looking for documentation on how to use Powertools for AWS Lambda (.NET) utilities and code samples?
 >  
 > 👉 [Here](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is the perfect place to start.
 
 ## Feedback
 
-If you have any feedback, create a new issue in the *AWS Lambda Powertools for .NET* repository on [GitHub](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues).
+If you have any feedback, create a new issue in the *Powertools for AWS Lambda (.NET)* repository on [GitHub](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues).

--- a/apidocs/toc.yml
+++ b/apidocs/toc.yml
@@ -1,5 +1,5 @@
 - name: API Documentation
   href: api/
   homepage: api/index.md
-- name: AWS Lambda Powertools for .NET Documentation
+- name: Powertools for AWS Lambda (.NET) Documentation
   href: "https://awslabs.github.io/aws-lambda-powertools-dotnet/"

--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -14,7 +14,7 @@ The logging utility provides a Lambda optimized logger with output structured as
 
 ## Installation
 
-Powertools are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*){target="_blank"} or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
+Powertools for AWS Lambda (.NET) are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*){target="_blank"} or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
 
 * [AWS.Lambda.Powertools.Logging](https://www.nuget.org/packages?q=AWS.Lambda.Powertools.Logging):
 
@@ -45,7 +45,7 @@ Here is an example using the AWS SAM [Globals section](https://docs.aws.amazon.c
     AWSTemplateFormatVersion: "2010-09-09"
     Transform: AWS::Serverless-2016-10-31
     Description: >
-    Example project for Powertools Logging utility
+    Example project for Powertools for AWS Lambda (.NET) Logging utility
 
     Globals:
         Function:
@@ -77,7 +77,7 @@ Key | Type | Example | Description
 ------------------------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------
 **Timestamp** | string | "2020-05-24 18:17:33,774" | Timestamp of actual log statement
 **Level** | string | "Information" | Logging level
-**Name** | string | "Powertools Logger" | Logger name
+**Name** | string | "Powertools for AWS Lambda (.NET) Logger" | Logger name
 **ColdStart** | bool | true| ColdStart value.
 **Service** | string | "payment" | Service name defined. "service_undefined" will be used if unknown
 **SamplingRate** | int |  0.1 | Debug logging sampling rate in percentage e.g. 10% in this case
@@ -445,7 +445,7 @@ via `SamplingRate` parameter on attribute.
 
 ## Configure Log Output Casing
 
-By definition Powertools outputs logging keys using **snake case** (e.g. *"function_memory_size": 128*). This allows developers using different Powertools runtimes, to search logs across services written in languages such as Python or TypeScript.
+By definition Powertools for AWS Lambda (.NET) outputs logging keys using **snake case** (e.g. *"function_memory_size": 128*). This allows developers using different Powertools for AWS Lambda (.NET) runtimes, to search logs across services written in languages such as Python or TypeScript.
 
 If you want to override the default behavior you can either set the desired casing through attributes, as described in the example below, or by setting the `POWERTOOLS_LOGGER_CASE` environment variable on your AWS Lambda function. Allowed values are: `CamelCase`, `PascalCase` and `SnakeCase`.
 

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -23,7 +23,7 @@ These metrics can be visualized through [Amazon CloudWatch Console](https://aws.
 
 ## Installation
 
-Powertools are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*){target="_blank"} or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
+Powertools for AWS Lambda (.NET) are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*){target="_blank"} or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
 
 * [AWS.Lambda.Powertools.Metrics](https://www.nuget.org/packages?q=AWS.Lambda.Powertools.Metrics):
 

--- a/docs/core/tracing.md
+++ b/docs/core/tracing.md
@@ -3,7 +3,7 @@ title: Tracing
 description: Core utility
 ---
 
-Powertools tracing is an opinionated thin wrapper for [AWS X-Ray .NET SDK](https://github.com/aws/aws-xray-sdk-dotnet/)
+Powertools for AWS Lambda (.NET) tracing is an opinionated thin wrapper for [AWS X-Ray .NET SDK](https://github.com/aws/aws-xray-sdk-dotnet/)
 a provides functionality to reduce the overhead of performing common tracing tasks.
 
 ![Tracing showcase](../media/tracer_utility_showcase.png)
@@ -18,7 +18,7 @@ a provides functionality to reduce the overhead of performing common tracing tas
 
 ## Installation
 
-Powertools are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*){target="_blank"} or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
+Powertools for AWS Lambda (.NET) are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*){target="_blank"} or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
 
 * [AWS.Lambda.Powertools.Tracing](https://www.nuget.org/packages?q=AWS.Lambda.Powertools.Tracing):
 
@@ -48,7 +48,7 @@ To enable active tracing on an AWS Serverless Application Model (AWS SAM) AWS::S
                     POWERTOOLS_SERVICE_NAME: example
     ```
 
-The Powertools service name is used as the X-Ray namespace. This can be set using the environment variable
+The Powertools for AWS Lambda (.NET) service name is used as the X-Ray namespace. This can be set using the environment variable
 `POWERTOOLS_SERVICE_NAME`
 
 ## Full list of environment variables
@@ -62,7 +62,7 @@ The Powertools service name is used as the X-Ray namespace. This can be set usin
 
 ### Lambda handler
 
-To enable Powertools tracing to your function add the `[Tracing]` attribute to your `FunctionHandler` method or on
+To enable Powertools for AWS Lambda (.NET) tracing to your function add the `[Tracing]` attribute to your `FunctionHandler` method or on
 any method will capture the method as a separate subsegment automatically. You can optionally choose to customize
 segment name that appears in traces.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,13 @@
 ---
-title: AWS Lambda Powertools for .NET
-description: AWS Lambda Powertools for .NET
+title: Powertools for AWS Lambda (.NET)
+description: Powertools for AWS Lambda (.NET)
 ---
 
 <!-- markdownlint-disable MD043 MD013 -->
 
-# AWS Lambda Powertools for .NET
+# Powertools for AWS Lambda (.NET)
 
-AWS Lambda Powertools for .NET (which from here will be referred as Powertools) is a suite of utilities for [AWS Lambda](https://aws.amazon.com/lambda/) functions to ease adopting best practices such as tracing, structured logging, custom metrics, and more. Please note, **Powertools is optimized for .NET 6+**.
+Powertools for AWS Lambda (.NET) (which from here will be referred as Powertools) is a suite of utilities for [AWS Lambda](https://aws.amazon.com/lambda/) functions to ease adopting best practices such as tracing, structured logging, custom metrics, and more. Please note, **Powertools for AWS Lambda (.NET) is optimized for .NET 6+**.
 
 ???+ tip
     Powertools is also available for [Python](https://awslabs.github.io/aws-lambda-powertools-python/){target="_blank"}, [Java](https://awslabs.github.io/aws-lambda-powertools-java/){target="_blank"}, and [TypeScript](https://awslabs.github.io/aws-lambda-powertools-typescript/latest/){target="_blank"}.
@@ -22,7 +22,7 @@ AWS Lambda Powertools for .NET (which from here will be referred as Powertools) 
 
 ## Features
 
-Core utilities such as Tracing, Logging, and Metrics will be available across all Lambda Powertools languages. Additional utilities are subjective to each language ecosystem and customer demand.
+Core utilities such as Tracing, Logging, and Metrics will be available across all Powertools for AWS Lambda languages. Additional utilities are subjective to each language ecosystem and customer demand.
 
 | Utility | Description
 | ------------------------------------------------- | ---------------------------------------------------------------------------------
@@ -32,7 +32,7 @@ Core utilities such as Tracing, Logging, and Metrics will be available across al
 
 ## Install
 
-Powertools are available as NuGet packages. You can install the packages from NuGet gallery or from Visual Studio editor. Search `AWS.Lambda.Powertools*` to see various utilities available.
+Powertools for AWS Lambda (.NET) is available as NuGet packages. You can install the packages from NuGet gallery or from Visual Studio editor. Search `AWS.Lambda.Powertools*` to see various utilities available.
 
 * [AWS.Lambda.Powertools.Tracing](https://www.nuget.org/packages?q=AWS.Lambda.Powertools.Tracing):
 
@@ -48,7 +48,7 @@ Powertools are available as NuGet packages. You can install the packages from Nu
 
 ### SAM CLI custom template
 
-We have provided you with a custom template for the Serverless Application Model (AWS SAM) command-line interface (CLI). This generates a starter project that allows you to interactively choose the Powertools features that enables you to include in your project.
+We have provided you with a custom template for the Serverless Application Model (AWS SAM) command-line interface (CLI). This generates a starter project that allows you to interactively choose the Powertools for AWS Lambda (.NET) features that enables you to include in your project.
 
 ```bash
 sam init --location https://github.com/aws-samples/cookiecutter-aws-sam-dotnet
@@ -62,7 +62,7 @@ To use the SAM CLI, you need the following tools.
 
 ## Examples
 
-We have provided a few examples that should you how to use the each of the core Powertools features.
+We have provided a few examples that should you how to use the each of the core Powertools for AWS Lambda (.NET) features.
 
 * [Tracing](https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/main/examples/Tracing){target="_blank"} example
 * [Logging](https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/main/examples/Logging/){target="_blank"} example
@@ -70,7 +70,7 @@ We have provided a few examples that should you how to use the each of the core 
 
 ## Connect
 
-* **AWS Lambda Powertools on Discord**: `#dotnet` - **[Invite link](https://discord.gg/B8zZKbbyET){target="_blank"}**
+* **Powertools for AWS Lambda (.NET) on Discord**: `#dotnet` - **[Invite link](https://discord.gg/B8zZKbbyET){target="_blank"}**
 * **Email**: aws-lambda-powertools-feedback@amazon.com
 
 ## Tenets

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,6 +1,6 @@
 ---
-title: AWS Lambda Powertools for .NET references
-description: AWS Lambda Powertools for .NET references
+title: Powertools for AWS Lambda (.NET) references
+description: Powertools for AWS Lambda (.NET) references
 ---
 
 ## Environment variables
@@ -30,7 +30,7 @@ description: AWS Lambda Powertools for .NET references
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  Example project for Powertools Logging utility
+  Example project for Powertools for AWS Lambda (.NET) Logging utility
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
@@ -54,7 +54,7 @@ Globals:
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  Example project for Powertools Metrics utility
+  Example project for Powertools for AWS Lambda (.NET) Metrics utility
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
@@ -74,7 +74,7 @@ Globals:
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  Example project for Powertools tracing utility
+  Example project for Powertools for AWS Lambda (.NET) tracing utility
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,11 +12,11 @@ Themes are key activities maintainers are focusing on, besides bug reports. Thes
 
 We are beta testing the [new GitHub Projects Beta](https://github.com/orgs/awslabs/projects/56/views/1?query=is%3Aopen+sort%3Aupdated-desc){target="_blank"} to provide more visibility on our current activities. This also includes new GitHub Issue Forms Beta to streamline feature requests, bug reports, RFCs, etc., including a new mechanism to add external links like `Ask a Question`.
 
-Once complete, we will repurpose our [central roadmap repository](https://github.com/awslabs/aws-lambda-powertools-roadmap){target="_blank"} to provide a landing page for all Powertools languages, including an experiment to better highlight feature parity across them.
+Once complete, we will repurpose our [central roadmap repository](https://github.com/awslabs/aws-lambda-powertools-roadmap){target="_blank"} to provide a landing page for all Powertools for AWS Lambda languages, including an experiment to better highlight feature parity across them.
 
 ## Disclaimer
 
-The AWS Lambda Powertools team values feedback and guidance from its community of users, although final decisions on inclusion into the project will be made by AWS.
+The Powertools for AWS Lambda team values feedback and guidance from its community of users, although final decisions on inclusion into the project will be made by AWS.
 
 We determine the high-level direction for our open roadmap based on customer feedback and popularity (👍🏽 and comments), security and operational impacts, and business value. Where features don’t meet our goals and longer-term strategy, we will communicate that clearly and openly as quickly as possible with an explanation of why the decision was made.
 

--- a/docs/tenets.md
+++ b/docs/tenets.md
@@ -1,9 +1,9 @@
 ---
-title: AWS Lambda Powertools for .NET (developer preview)
-description: AWS Lambda Powertools for .NET (developer preview)
+title: Powertools for AWS Lambda (.NET) (developer preview)
+description: Powertools for AWS Lambda (.NET) (developer preview)
 ---
 
-Core utilities such as Tracing, Logging, Metrics, and Event Handler will be available across all Powertools runtimes. Additional utilities are subjective to each language ecosystem and customer demand.
+Core utilities such as Tracing, Logging, Metrics, and Event Handler will be available across all Powertools for AWS Lambda runtimes. Additional utilities are subjective to each language ecosystem and customer demand.
 
 * **AWS Lambda only**. We optimize for AWS Lambda function environments and supported runtimes only. Utilities might work with web frameworks and non-Lambda environments, though they are not officially supported.
 * **Eases the adoption of best practices**. The main priority of the utilities is to facilitate best practices adoption, as defined in the AWS Well-Architected Serverless Lens; all other functionality is optional.

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -18,7 +18,7 @@ The Parameters utility provides high-level functionality to retrieve one or mult
 
 ## Installation
 
-Powertools are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*){target="_blank"} or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
+Powertools for AWS Lambda (.NET) are available as NuGet packages. You can install the packages from [NuGet Gallery](https://www.nuget.org/packages?q=AWS+Lambda+Powertools*){target="_blank"} or from Visual Studio editor by searching `AWS.Lambda.Powertools*` to see various utilities available.
 
 * [AWS.Lambda.Powertools.Parameters](https://www.nuget.org/packages?q=AWS.Lambda.Powertools.Parameters):
 

--- a/docs/we_made_this.md
+++ b/docs/we_made_this.md
@@ -1,11 +1,11 @@
 ---
 title: We Made This (Community)
-description: Blog posts, tutorials, and videos about AWS Lambda Powertools created by the Powertools Community.
+description: Blog posts, tutorials, and videos about Powertools for AWS Lambda created by the Powertools for AWS Lambda Community.
 ---
 
 <!-- markdownlint-disable  MD001 MD043 -->
 
-This space is dedicated to highlight our awesome community content featuring Powertools 🙏!
+This space is dedicated to highlight our awesome community content featuring Powertools for AWS Lambda (.NET) 🙏!
 
 !!! info "[Get your content featured here](https://github.com/awslabs/aws-lambda-powertools-python/issues/new?assignees=&labels=community-content&template=share_your_work.yml&title=%5BI+Made+This%5D%3A+%3CTITLE%3E){target="_blank"}!"
 
@@ -13,7 +13,7 @@ This space is dedicated to highlight our awesome community content featuring Pow
 
 [![Join our Discord](https://dcbadge.vercel.app/api/server/B8zZKbbyET)](https://discord.gg/B8zZKbbyET){target="_blank"}
 
-Join us on [Discord](https://discord.gg/B8zZKbbyET){target="_blank"} to connect with the Powertools community 👋. Ask questions, learn from each other, contribute, hang out with key contributors, and more!
+Join us on [Discord](https://discord.gg/B8zZKbbyET){target="_blank"} to connect with the Powertools for AWS Lambda community 👋. Ask questions, learn from each other, contribute, hang out with key contributors, and more!
 
 <!-- ## Blog posts
 

--- a/examples/Logging/README.md
+++ b/examples/Logging/README.md
@@ -1,4 +1,4 @@
-# AWS Lambda Powertools for .NET - Logging Example
+# Powertools for AWS Lambda (.NET) - Logging Example
 
 This project contains source code and supporting files for a serverless application that you can deploy with the AWS Serverless Application Model Command Line Interface (AWS SAM CLI). It includes the following files and folders.
 

--- a/examples/Logging/src/HelloWorld/Function.cs
+++ b/examples/Logging/src/HelloWorld/Function.cs
@@ -86,7 +86,7 @@ public class Function
         var location = await GetCallingIp();
 
         var lookupRecord = new LookupRecord(lookupId: requestContextRequestId,
-            greeting: "Hello AWS Lambda Powertools for .NET", ipAddress: location);
+            greeting: "Hello Powertools for AWS Lambda (.NET)", ipAddress: location);
 
         try
         {

--- a/examples/Logging/template-docker.yaml
+++ b/examples/Logging/template-docker.yaml
@@ -3,7 +3,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  Example project for AWS Lambda Powertools Logging utility
+  Example project for Powertools for AWS Lambda (.NET) Logging utility
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:

--- a/examples/Logging/template.yaml
+++ b/examples/Logging/template.yaml
@@ -3,7 +3,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  Example project for AWS Lambda Powertools Logging utility
+  Example project for Powertools for AWS Lambda (.NET) Logging utility
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:

--- a/examples/Logging/test/HelloWorld.Test/FunctionTest.cs
+++ b/examples/Logging/test/HelloWorld.Test/FunctionTest.cs
@@ -83,7 +83,7 @@ namespace HelloWorld.Tests
             var body = new Dictionary<string, string>
             {
                 { "LookupId", requestId },
-                { "Greeting", "Hello AWS Lambda Powertools for .NET" },
+                { "Greeting", "Hello Powertools for AWS Lambda (.NET)" },
                 { "IpAddress", location },
             };
 

--- a/examples/Metrics/README.md
+++ b/examples/Metrics/README.md
@@ -1,4 +1,4 @@
-# AWS Lambda Powertools for .NET - Metrics Example
+# Powertools for AWS Lambda (.NET) - Metrics Example
 
 This project contains source code and supporting files for a serverless application that you can deploy with the AWS Serverless Application Model Command Line Interface (AWS SAM CLI). It includes the following files and folders.
 

--- a/examples/Metrics/src/HelloWorld/Function.cs
+++ b/examples/Metrics/src/HelloWorld/Function.cs
@@ -99,7 +99,7 @@ public class Function
         Metrics.AddMetric("SuccessfulLocations", 1, MetricUnit.Count);
         
         var lookupRecord = new LookupRecord(lookupId: requestContextRequestId,
-            greeting: "Hello AWS Lambda Powertools for .NET", ipAddress: location);
+            greeting: "Hello Powertools for AWS Lambda (.NET)", ipAddress: location);
 
         try
         {

--- a/examples/Metrics/template-docker.yaml
+++ b/examples/Metrics/template-docker.yaml
@@ -3,7 +3,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  Example project for AWS Lambda Powertools Metrics utility
+  Example project for Powertools for AWS Lambda (.NET) Metrics utility
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:

--- a/examples/Metrics/template.yaml
+++ b/examples/Metrics/template.yaml
@@ -3,7 +3,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  Example project for AWS Lambda Powertools Metrics utility
+  Example project for Powertools for AWS Lambda (.NET) Metrics utility
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:

--- a/examples/Metrics/test/HelloWorld.Test/FunctionTest.cs
+++ b/examples/Metrics/test/HelloWorld.Test/FunctionTest.cs
@@ -83,7 +83,7 @@ namespace HelloWorld.Tests
             var body = new Dictionary<string, string>
             {
                 { "LookupId", requestId },
-                { "Greeting", "Hello AWS Lambda Powertools for .NET" },
+                { "Greeting", "Hello Powertools for AWS Lambda (.NET)" },
                 { "IpAddress", location },
             };
 

--- a/examples/Tracing/README.md
+++ b/examples/Tracing/README.md
@@ -1,4 +1,4 @@
-# AWS Lambda Powertools for .NET - Tracing Example
+# Powertools for AWS Lambda (.NET) - Tracing Example
 
 This project contains source code and supporting files for a serverless application that you can deploy with the AWS Serverless Application Model Command Line Interface (AWS SAM CLI). It includes the following files and folders.
 

--- a/examples/Tracing/src/HelloWorld/Function.cs
+++ b/examples/Tracing/src/HelloWorld/Function.cs
@@ -85,7 +85,7 @@ public class Function
         var location = await GetCallingIp().ConfigureAwait(false);
 
         var lookupRecord = new LookupRecord(lookupId: requestContextRequestId,
-            greeting: "Hello AWS Lambda Powertools for .NET", ipAddress: location);
+            greeting: "Hello Powertools for AWS Lambda (.NET)", ipAddress: location);
 
         // Trace Fluent API
         Tracing.WithSubsegment("LoggingResponse",

--- a/examples/Tracing/template-docker.yaml
+++ b/examples/Tracing/template-docker.yaml
@@ -3,7 +3,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  Example project for AWS Lambda Powertools tracing utility
+  Example project for Powertools for AWS Lambda (.NET) tracing utility
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:

--- a/examples/Tracing/template.yaml
+++ b/examples/Tracing/template.yaml
@@ -3,7 +3,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  Example project for AWS Lambda Powertools tracing utility
+  Example project for Powertools for AWS Lambda (.NET) tracing utility
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:

--- a/examples/Tracing/test/HelloWorld.Test/FunctionTest.cs
+++ b/examples/Tracing/test/HelloWorld.Test/FunctionTest.cs
@@ -83,7 +83,7 @@ namespace HelloWorld.Tests
             var body = new Dictionary<string, string>
             {
                 { "LookupId", requestId },
-                { "Greeting", "Hello AWS Lambda Powertools for .NET" },
+                { "Greeting", "Hello Powertools for AWS Lambda (.NET)" },
                 { "IpAddress", location },
             };
 

--- a/libraries/src/AWS.Lambda.Powertools.Common/AWS.Lambda.Powertools.Common.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Common/AWS.Lambda.Powertools.Common.csproj
@@ -7,8 +7,8 @@
       <Authors>Amazon Web Services</Authors>
       <Company>Amazon.com, Inc</Company>
       <LangVersion>default</LangVersion>
-      <Title>AWS Lambda Powertools for .NET</Title>
-      <Description>AWS Lambda Powertools for .NET - Core package.</Description>
+      <Title>Powertools for AWS Lambda (.NET)</Title>
+      <Description>Powertools for AWS Lambda (.NET) - Core package.</Description>
       <Copyright>Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
       <RepositoryUrl>https://github.com/awslabs/aws-lambda-powertools-dotnet</RepositoryUrl>
       <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/libraries/src/AWS.Lambda.Powertools.Common/Core/Constants.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Common/Core/Constants.cs
@@ -87,7 +87,7 @@ internal static class Constants
     internal const string AwsExecutionEnvironmentVariableName = "AWS_EXECUTION_ENV";
     
     /// <summary>
-    ///     Constant for Powertools feature identifier fo AWS_EXECUTION_ENV environment variable
+    ///     Constant for Powertools for AWS Lambda (.NET) feature identifier fo AWS_EXECUTION_ENV environment variable
     /// </summary>
     internal const string FeatureContextIdentifier = "PT";
 }

--- a/libraries/src/AWS.Lambda.Powertools.Common/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Common/README.md
@@ -1,3 +1,3 @@
 # AWS.Lambda.Powertools.Common
 
-AWS Lambda Powertools for .NET Common library
+Powertools for AWS Lambda (.NET) Common library

--- a/libraries/src/AWS.Lambda.Powertools.Logging/AWS.Lambda.Powertools.Logging.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/AWS.Lambda.Powertools.Logging.csproj
@@ -7,8 +7,8 @@
         <Version>0.0.1</Version>
         <Authors>Amazon Web Services</Authors>
         <Company>Amazon.com, Inc</Company>
-        <Title>AWS Lambda Powertools for .NET</Title>
-        <Description>AWS Lambda Powertools for .NET - Logging package.</Description>
+        <Title>Powertools for AWS Lambda (.NET)</Title>
+        <Description>Powertools for AWS Lambda (.NET) - Logging package.</Description>
         <Copyright>Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
         <RepositoryUrl>https://github.com/awslabs/aws-lambda-powertools-dotnet</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspectHandler.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/LoggingAspectHandler.cs
@@ -67,7 +67,7 @@ internal class LoggingAspectHandler : IMethodAspectHandler
     private readonly LoggerOutputCase? _loggerOutputCase;
 
     /// <summary>
-    ///     The Powertools configurations
+    ///     The Powertools for AWS Lambda (.NET) configurations
     /// </summary>
     private readonly IPowertoolsConfigurations _powertoolsConfigurations;
 

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsConfigurations.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsConfigurations.cs
@@ -27,7 +27,7 @@ internal static class PowertoolsConfigurationsExtension
     /// <summary>
     ///     Gets the log level.
     /// </summary>
-    /// <param name="powertoolsConfigurations">The Powertools configurations.</param>
+    /// <param name="powertoolsConfigurations">The Powertools for AWS Lambda (.NET) configurations.</param>
     /// <param name="logLevel">The log level.</param>
     /// <returns>LogLevel.</returns>
     internal static LogLevel GetLogLevel(this IPowertoolsConfigurations powertoolsConfigurations,

--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
@@ -42,7 +42,7 @@ internal sealed class PowertoolsLogger : ILogger
     private readonly string _name;
 
     /// <summary>
-    ///     The Powertools configurations
+    ///     The Powertools for AWS Lambda (.NET) configurations
     /// </summary>
     private readonly IPowertoolsConfigurations _powertoolsConfigurations;
 
@@ -65,7 +65,7 @@ internal sealed class PowertoolsLogger : ILogger
     ///     Initializes a new instance of the <see cref="PowertoolsLogger" /> class.
     /// </summary>
     /// <param name="name">The name.</param>
-    /// <param name="powertoolsConfigurations">The Powertools configurations.</param>
+    /// <param name="powertoolsConfigurations">The Powertools for AWS Lambda (.NET) configurations.</param>
     /// <param name="systemWrapper">The system wrapper.</param>
     /// <param name="getCurrentConfig">The get current configuration.</param>
     public PowertoolsLogger(

--- a/libraries/src/AWS.Lambda.Powertools.Logging/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/README.md
@@ -42,7 +42,7 @@ public class Function
         var location = await GetCallingIp();
 
         var lookupRecord = new LookupRecord(lookupId: requestContextRequestId,
-            greeting: "Hello AWS Lambda Powertools for .NET", ipAddress: location);
+            greeting: "Hello Powertools for AWS Lambda (.NET)", ipAddress: location);
 
         try
         {

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/AWS.Lambda.Powertools.Metrics.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/AWS.Lambda.Powertools.Metrics.csproj
@@ -6,8 +6,8 @@
         <Version>0.0.1</Version>
         <Authors>Amazon Web Services</Authors>
         <Company>Amazon.com, Inc</Company>
-        <Title>AWS Lambda Powertools for .NET</Title>
-        <Description>AWS Lambda Powertools for .NET - Metrics package.</Description>
+        <Title>Powertools for AWS Lambda (.NET)</Title>
+        <Description>Powertools for AWS Lambda (.NET) - Metrics package.</Description>
         <Copyright>Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
         <RepositoryUrl>https://github.com/awslabs/aws-lambda-powertools-dotnet</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/Metrics.cs
@@ -37,12 +37,12 @@ public class Metrics : IMetrics
     private readonly MetricsContext _context;
 
     /// <summary>
-    ///     The Powertools configurations
+    ///     The Powertools for AWS Lambda (.NET) configurations
     /// </summary>
     private readonly IPowertoolsConfigurations _powertoolsConfigurations;
 
     /// <summary>
-    ///     If true, Powertools will throw an exception on empty metrics when trying to flush
+    ///     If true, Powertools for AWS Lambda (.NET) will throw an exception on empty metrics when trying to flush
     /// </summary>
     private readonly bool _raiseOnEmptyMetrics;
     
@@ -56,7 +56,7 @@ public class Metrics : IMetrics
     ///     format (EMF). See
     ///     https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
     /// </summary>
-    /// <param name="powertoolsConfigurations">Lambda Powertools Configuration</param>
+    /// <param name="powertoolsConfigurations">Powertools for AWS Lambda (.NET) Configuration</param>
     /// <param name="nameSpace">Metrics Namespace Identifier</param>
     /// <param name="service">Metrics Service Name</param>
     /// <param name="raiseOnEmptyMetrics">Instructs metrics validation to throw exception if no metrics are provided</param>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/README.md
@@ -58,7 +58,7 @@ public class Function
         Metrics.AddMetric("SuccessfulLocations", 1, MetricUnit.Count);
         
         var lookupRecord = new LookupRecord(lookupId: requestContextRequestId,
-            greeting: "Hello AWS Lambda Powertools for .NET", ipAddress: location);
+            greeting: "Hello Powertools for AWS Lambda (.NET)", ipAddress: location);
 
         try
         {

--- a/libraries/src/AWS.Lambda.Powertools.Parameters/AWS.Lambda.Powertools.Parameters.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Parameters/AWS.Lambda.Powertools.Parameters.csproj
@@ -9,8 +9,8 @@
         <Version>0.0.1</Version>
         <Authors>Amazon Web Services</Authors>
         <Company>Amazon.com, Inc</Company>
-        <Title>AWS Lambda Powertools for .NET</Title>
-        <Description>AWS Lambda Powertools for .NET - Parameters package.</Description>
+        <Title>Powertools for AWS Lambda (.NET)</Title>
+        <Description>Powertools for AWS Lambda (.NET) - Parameters package.</Description>
         <Copyright>Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
         <RepositoryUrl>https://github.com/awslabs/aws-lambda-powertools-dotnet</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/libraries/src/AWS.Lambda.Powertools.Parameters/Internal/Provider/ParameterProviderBaseHandler.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Parameters/Internal/Provider/ParameterProviderBaseHandler.cs
@@ -90,7 +90,7 @@ internal class ParameterProviderBaseHandler : IParameterProviderBaseHandler
     /// <param name="getAsyncHandler">The parameter provider GetAsync callback handler.</param>
     /// <param name="getMultipleAsyncHandler">The parameter provider GetMultipleAsync callback handler.</param>
     /// <param name="cacheMode">The CacheMode.</param>
-    /// <param name="powertoolsConfigurations">The Powertools configurations.</param>
+    /// <param name="powertoolsConfigurations">The Powertools for AWS Lambda (.NET) configurations.</param>
     internal ParameterProviderBaseHandler(GetAsyncDelegate getAsyncHandler,
         GetMultipleAsyncDelegate getMultipleAsyncHandler,
         ParameterProviderCacheMode cacheMode,

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/AWS.Lambda.Powertools.Tracing.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/AWS.Lambda.Powertools.Tracing.csproj
@@ -7,8 +7,8 @@
         <Version>0.0.1</Version>
         <Authors>Amazon Web Services</Authors>
         <Company>Amazon.com, Inc</Company>
-        <Title>AWS Lambda Powertools for .NET</Title>
-        <Description>AWS Lambda Powertools for .NET - Tracing package.</Description>
+        <Title>Powertools for AWS Lambda (.NET)</Title>
+        <Description>Powertools for AWS Lambda (.NET) - Tracing package.</Description>
         <Copyright>Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
         <RepositoryUrl>https://github.com/awslabs/aws-lambda-powertools-dotnet</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingAspectHandler.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/Internal/TracingAspectHandler.cs
@@ -52,7 +52,7 @@ internal class TracingAspectHandler : IMethodAspectHandler
     private readonly string _namespace;
 
     /// <summary>
-    ///     The Powertools configurations
+    ///     The Powertools for AWS Lambda (.NET) configurations
     /// </summary>
     private readonly IPowertoolsConfigurations _powertoolsConfigurations;
 
@@ -77,7 +77,7 @@ internal class TracingAspectHandler : IMethodAspectHandler
     /// <param name="segmentName">Name of the segment.</param>
     /// <param name="nameSpace">The namespace.</param>
     /// <param name="captureMode">The capture mode.</param>
-    /// <param name="powertoolsConfigurations">The Powertools configurations.</param>
+    /// <param name="powertoolsConfigurations">The Powertools for AWS Lambda (.NET) configurations.</param>
     /// <param name="xRayRecorder">The X-Ray recorder.</param>
     internal TracingAspectHandler
     (

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/README.md
@@ -1,6 +1,6 @@
 # AWS.Lambda.Powertools.Tracing
 
-Powertools tracing is an opinionated thin wrapper for [AWS X-Ray .NET SDK](https://github.com/aws/aws-xray-sdk-dotnet/)
+Powertools for AWS Lambda (.NET) tracing is an opinionated thin wrapper for [AWS X-Ray .NET SDK](https://github.com/aws/aws-xray-sdk-dotnet/)
 a provides functionality to reduce the overhead of performing common tracing tasks.
 
 ## Key Features
@@ -42,7 +42,7 @@ public class Function
         var location = await GetCallingIp().ConfigureAwait(false);
 
         var lookupRecord = new LookupRecord(lookupId: requestContextRequestId,
-            greeting: "Hello AWS Lambda Powertools for .NET", ipAddress: location);
+            greeting: "Hello Powertools for AWS Lambda (.NET)", ipAddress: location);
 
         // Trace Fluent API
         Tracing.WithSubsegment("LoggingResponse",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: Lambda Powertools .NET
-site_description: AWS Lambda Powertools for .NET
+site_name: Powertools for AWS Lambda (.NET)
+site_description: Powertools for AWS Lambda (.NET)
 site_author: Amazon Web Services
 repo_url: https://github.com/awslabs/aws-lambda-powertools-dotnet
 edit_uri: edit/develop/docs


### PR DESCRIPTION
> Please provide the issue number

Issue number: #281 

## Summary

### Changes

> Please provide a summary of what's being changed

Located all references of Powertools/Lambda Powertools etc and updated to the new project name "Powertools for AWS Lambda"


## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [X] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
